### PR TITLE
feat: add OIDC groups scope and scope-gated claims

### DIFF
--- a/custom_components/oidc_provider/const.py
+++ b/custom_components/oidc_provider/const.py
@@ -16,8 +16,27 @@ AUTHORIZATION_CODE_EXPIRY = 600  # 10 minutes
 SCOPE_OPENID = "openid"
 SCOPE_PROFILE = "profile"
 SCOPE_EMAIL = "email"
+SCOPE_GROUPS = "groups"
 
-SUPPORTED_SCOPES = [SCOPE_OPENID, SCOPE_PROFILE, SCOPE_EMAIL]
+SUPPORTED_SCOPES = [SCOPE_OPENID, SCOPE_PROFILE, SCOPE_EMAIL, SCOPE_GROUPS]
+
+# Home Assistant group IDs
+HA_GROUP_ID_ADMIN = "system-admin"
+HA_GROUP_ID_USER = "system-users"
+HA_GROUP_ID_READ_ONLY = "system-read-only"
+
+# OIDC group names
+GROUP_OWNER = "owner"
+GROUP_ADMIN = "admin"
+GROUP_USER = "user"
+GROUP_READ_ONLY = "read-only"
+
+# Mapping from HA group IDs to OIDC group names
+HA_GROUP_TO_OIDC_GROUP = {
+    HA_GROUP_ID_ADMIN: GROUP_ADMIN,
+    HA_GROUP_ID_USER: GROUP_USER,
+    HA_GROUP_ID_READ_ONLY: GROUP_READ_ONLY,
+}
 
 # Grant types
 GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code"

--- a/custom_components/oidc_provider/http.py
+++ b/custom_components/oidc_provider/http.py
@@ -28,11 +28,17 @@ from .const import (
     DOMAIN,
     GRANT_TYPE_AUTHORIZATION_CODE,
     GRANT_TYPE_REFRESH_TOKEN,
+    GROUP_OWNER,
+    HA_GROUP_TO_OIDC_GROUP,
     MAX_TOKEN_ATTEMPTS,
     RATE_LIMIT_PENALTY,
     RATE_LIMIT_WINDOW,
     REFRESH_TOKEN_EXPIRY,
     RESPONSE_TYPE_CODE,
+    SCOPE_EMAIL,
+    SCOPE_GROUPS,
+    SCOPE_OPENID,
+    SCOPE_PROFILE,
     STORAGE_KEY_KEYS,
     STORAGE_VERSION,
     SUPPORTED_CODE_CHALLENGE_METHODS,
@@ -97,6 +103,29 @@ async def _load_or_generate_keys(hass: HomeAssistant) -> tuple[Any, str]:
         _LOGGER.info("RSA key pair generated and saved to storage with kid: %s", kid)
 
     return private_key, kid
+
+
+def _resolve_user_groups(user: Any) -> list[str]:
+    """Resolve OIDC groups from a Home Assistant user."""
+    groups = []
+
+    if getattr(user, "is_owner", False):
+        groups.append(GROUP_OWNER)
+
+    for group in getattr(user, "groups", []):
+        oidc_group = HA_GROUP_TO_OIDC_GROUP.get(group.id)
+        if oidc_group:
+            groups.append(oidc_group)
+
+    return groups
+
+
+def _looks_like_email(value: str) -> bool:
+    """Check if a string looks like an email address."""
+    if not value or "@" not in value:
+        return False
+    local, _, domain = value.rpartition("@")
+    return bool(local) and "." in domain
 
 
 async def setup_http_endpoints(hass: HomeAssistant) -> None:
@@ -213,6 +242,8 @@ class OIDCDiscoveryView(HomeAssistantView):
                 "sub",
                 "name",
                 "email",
+                "email_verified",
+                "groups",
                 "iss",
                 "aud",
                 "exp",
@@ -315,6 +346,14 @@ class OIDCAuthorizationView(HomeAssistantView):
         # Validate parameters
         if not client_id or not redirect_uri or response_type != RESPONSE_TYPE_CODE:
             return web.Response(text="Invalid request", status=400)
+
+        # Validate that openid scope is present (required by OIDC Core Section 3.1.2.1)
+        requested_scopes = scope.split() if scope else []
+        if SCOPE_OPENID not in requested_scopes:
+            return web.Response(
+                text="The openid scope is required for OIDC requests.",
+                status=400,
+            )
 
         # Check if PKCE is required
         require_pkce = hass.data[DOMAIN].get(CONF_REQUIRE_PKCE, DEFAULT_REQUIRE_PKCE)
@@ -592,7 +631,7 @@ class OIDCTokenView(HomeAssistantView):
         client_id = auth_data["client_id"]
         scope = auth_data["scope"]
 
-        access_token = self._generate_access_token(_request, hass, user_id, scope, client_id)
+        access_token = await self._generate_access_token(_request, hass, user_id, scope, client_id)
         refresh_token = secrets.token_urlsafe(32)
 
         # Store refresh token
@@ -641,7 +680,7 @@ class OIDCTokenView(HomeAssistantView):
             return web.json_response({"error": "invalid_grant"}, status=400)
 
         # Generate new access token
-        access_token = self._generate_access_token(
+        access_token = await self._generate_access_token(
             _request, hass, token_data["user_id"], token_data["scope"], token_data["client_id"]
         )
 
@@ -654,7 +693,7 @@ class OIDCTokenView(HomeAssistantView):
             }
         )
 
-    def _generate_access_token(
+    async def _generate_access_token(
         self, request: web.Request, hass: HomeAssistant, user_id: str, scope: str, client_id: str
     ) -> str:
         """Generate JWT access token."""
@@ -671,6 +710,13 @@ class OIDCTokenView(HomeAssistantView):
             "aud": client_id,
             "scope": scope,
         }
+
+        # Include groups claim when the groups scope is requested
+        requested_scopes = scope.split() if scope else []
+        if SCOPE_GROUPS in requested_scopes:
+            user = await hass.auth.async_get_user(user_id)
+            if user:
+                payload["groups"] = _resolve_user_groups(user)
 
         private_key = hass.data[DOMAIN]["jwt_private_key"]
         kid = hass.data[DOMAIN]["jwt_kid"]
@@ -746,13 +792,27 @@ class OIDCUserInfoView(HomeAssistantView):
             if not user:
                 return web.json_response({"error": "user_not_found"}, status=404)
 
-            return web.json_response(
-                {
-                    "sub": user.id,
-                    "name": user.name,
-                    "email": user.id,  # HA doesn't store email, use ID as fallback
-                }
-            )
+            userinfo = {
+                "sub": user.id,
+            }
+
+            # Include claims based on requested scopes
+            token_scope = payload.get("scope", "")
+            requested_scopes = token_scope.split() if token_scope else []
+
+            if SCOPE_PROFILE in requested_scopes:
+                userinfo["name"] = user.name
+
+            if SCOPE_EMAIL in requested_scopes:
+                username = user.name or ""
+                if _looks_like_email(username):
+                    userinfo["email"] = username
+                    userinfo["email_verified"] = False
+
+            if SCOPE_GROUPS in requested_scopes:
+                userinfo["groups"] = _resolve_user_groups(user)
+
+            return web.json_response(userinfo)
         except jwt.ExpiredSignatureError:
             _LOGGER.error("Token expired")
             return web.json_response({"error": "token_expired"}, status=401)

--- a/custom_components/oidc_provider/manifest.json
+++ b/custom_components/oidc_provider/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-oidc-server/issues",
   "requirements": ["PyJWT>=2.8.0", "cryptography>=43.0.0"],
-  "version": "1.2.1"
+  "version": "1.3.0"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,13 @@ def mock_user():
     user = Mock()
     user.id = "test_user_id"
     user.name = "Test User"
+    user.is_owner = False
+
+    # Default to admin group
+    admin_group = Mock()
+    admin_group.id = "system-admin"
+    user.groups = [admin_group]
+
     return user
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -627,6 +627,7 @@ async def test_oidc_authorization_view_invalid_client():
         "client_id": "nonexistent",
         "redirect_uri": "https://example.com/callback",
         "response_type": "code",
+        "scope": "openid",
     }
 
     from custom_components.oidc_provider.http import OIDCAuthorizationView
@@ -659,6 +660,7 @@ async def test_oidc_authorization_view_invalid_redirect_uri():
         "client_id": "test_client",
         "redirect_uri": "https://evil.com/callback",  # Not registered
         "response_type": "code",
+        "scope": "openid",
     }
 
     from custom_components.oidc_provider.http import OIDCAuthorizationView
@@ -691,6 +693,7 @@ async def test_oidc_authorization_view_unsupported_code_challenge_method():
         "client_id": "test_client",
         "redirect_uri": "https://example.com/callback",
         "response_type": "code",
+        "scope": "openid",
         "code_challenge": "test_challenge",
         "code_challenge_method": "plain",  # Not supported
     }
@@ -1307,6 +1310,187 @@ async def test_oidc_token_view_valid_pkce():
 
 
 @pytest.mark.asyncio
+async def test_oidc_token_view_includes_groups_in_access_token():
+    """Test token endpoint includes groups claim in JWT when groups scope is requested."""
+    import base64
+    import hashlib
+
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    from custom_components.oidc_provider.security import hash_client_secret
+
+    code_verifier = "valid_verifier_1234567890_abcdefghijklmnop"
+    verifier_hash = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    code_challenge = base64.urlsafe_b64encode(verifier_hash).decode("ascii").rstrip("=")
+
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    public_key = private_key.public_key()
+
+    mock_user = Mock()
+    mock_user.id = "user123"
+    mock_user.name = "Test User"
+    mock_user.is_owner = True
+    admin_group = Mock()
+    admin_group.id = "system-admin"
+    mock_user.groups = [admin_group]
+
+    mock_auth = Mock()
+    mock_auth.async_get_user = AsyncMock(return_value=mock_user)
+
+    mock_token_store = Mock()
+    mock_token_store.async_save = AsyncMock()
+
+    hass = Mock()
+    hass.auth = mock_auth
+    hass.data = {
+        DOMAIN: {
+            "clients": {
+                "test_client": {
+                    "client_secret_hash": hash_client_secret("test_secret"),
+                }
+            },
+            "authorization_codes": {
+                "valid_code": {
+                    "client_id": "test_client",
+                    "redirect_uri": "https://example.com/callback",
+                    "user_id": "user123",
+                    "scope": "openid groups",
+                    "expires_at": time.time() + 600,
+                    "code_challenge": code_challenge,
+                    "code_challenge_method": "S256",
+                }
+            },
+            "refresh_tokens": {},
+            "rate_limit_attempts": {},
+            "jwt_private_key": private_key,
+            "jwt_kid": "test-kid-1",
+            "token_store": mock_token_store,
+        }
+    }
+
+    request = MagicMock()
+    request.app = {"hass": hass}
+    request.remote = "127.0.0.1"
+    request.headers = {}
+    request.post = AsyncMock(
+        return_value={
+            "grant_type": "authorization_code",
+            "client_id": "test_client",
+            "client_secret": "test_secret",
+            "code": "valid_code",
+            "redirect_uri": "https://example.com/callback",
+            "code_verifier": code_verifier,
+        }
+    )
+
+    from custom_components.oidc_provider.http import OIDCTokenView
+
+    view = OIDCTokenView()
+    response = await view.post(request)
+
+    assert response.status == 200
+    data = json.loads(response.body.decode("utf-8"))
+
+    # Decode the access token and verify groups claim
+    public_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    token_payload = jwt.decode(
+        data["access_token"], public_pem, algorithms=["RS256"], options={"verify_aud": False}
+    )
+    assert token_payload["groups"] == ["owner", "admin"]
+
+
+@pytest.mark.asyncio
+async def test_oidc_token_view_excludes_groups_without_scope():
+    """Test token endpoint does not include groups claim when groups scope is not requested."""
+    import base64
+    import hashlib
+
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    from custom_components.oidc_provider.security import hash_client_secret
+
+    code_verifier = "valid_verifier_1234567890_abcdefghijklmnop"
+    verifier_hash = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    code_challenge = base64.urlsafe_b64encode(verifier_hash).decode("ascii").rstrip("=")
+
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    public_key = private_key.public_key()
+
+    mock_token_store = Mock()
+    mock_token_store.async_save = AsyncMock()
+
+    hass = Mock()
+    hass.data = {
+        DOMAIN: {
+            "clients": {
+                "test_client": {
+                    "client_secret_hash": hash_client_secret("test_secret"),
+                }
+            },
+            "authorization_codes": {
+                "valid_code": {
+                    "client_id": "test_client",
+                    "redirect_uri": "https://example.com/callback",
+                    "user_id": "user123",
+                    "scope": "openid profile",
+                    "expires_at": time.time() + 600,
+                    "code_challenge": code_challenge,
+                    "code_challenge_method": "S256",
+                }
+            },
+            "refresh_tokens": {},
+            "rate_limit_attempts": {},
+            "jwt_private_key": private_key,
+            "jwt_kid": "test-kid-1",
+            "token_store": mock_token_store,
+        }
+    }
+
+    request = MagicMock()
+    request.app = {"hass": hass}
+    request.remote = "127.0.0.1"
+    request.headers = {}
+    request.post = AsyncMock(
+        return_value={
+            "grant_type": "authorization_code",
+            "client_id": "test_client",
+            "client_secret": "test_secret",
+            "code": "valid_code",
+            "redirect_uri": "https://example.com/callback",
+            "code_verifier": code_verifier,
+        }
+    )
+
+    from custom_components.oidc_provider.http import OIDCTokenView
+
+    view = OIDCTokenView()
+    response = await view.post(request)
+
+    assert response.status == 200
+    data = json.loads(response.body.decode("utf-8"))
+
+    public_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    token_payload = jwt.decode(
+        data["access_token"], public_pem, algorithms=["RS256"], options={"verify_aud": False}
+    )
+    assert "groups" not in token_payload
+
+
+@pytest.mark.asyncio
 async def test_oidc_token_view_refresh_token():
     """Test token endpoint with refresh token grant."""
     from cryptography.hazmat.backends import default_backend
@@ -1491,15 +1675,14 @@ async def test_oidc_userinfo_endpoint():
     )
     public_key = private_key.public_key()
 
-    # Create a valid token
+    # Create a valid token with profile and email scopes
     payload = {
         "sub": "user123",
-        "name": "Test User",
-        "email": "test@example.com",
         "iat": int(time.time()),
         "exp": int(time.time()) + 3600,
         "iss": "http://localhost",
-        "aud": "test_client",  # Required audience
+        "aud": "test_client",
+        "scope": "openid profile email",
     }
 
     private_key_pem = private_key.private_bytes(
@@ -1514,6 +1697,10 @@ async def test_oidc_userinfo_endpoint():
     mock_user = Mock()
     mock_user.id = "user123"
     mock_user.name = "Test User"
+    mock_user.is_owner = False
+    admin_group = Mock()
+    admin_group.id = "system-admin"
+    mock_user.groups = [admin_group]
 
     # Mock hass.auth
     mock_auth = Mock()
@@ -1548,7 +1735,489 @@ async def test_oidc_userinfo_endpoint():
     data = json.loads(body)
     assert data["sub"] == "user123"
     assert data["name"] == "Test User"
-    assert data["email"] == "user123"  # HA uses user.id as email fallback
+    assert "email" not in data  # "Test User" doesn't look like an email
+    assert "groups" not in data
+
+
+@pytest.mark.asyncio
+async def test_oidc_userinfo_includes_groups_when_scope_requested():
+    """Test UserInfo endpoint includes groups when groups scope is requested."""
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    # Generate RSA keys
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    public_key = private_key.public_key()
+
+    # Create a valid token with groups scope
+    payload = {
+        "sub": "user123",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 3600,
+        "iss": "http://localhost",
+        "aud": "test_client",
+        "scope": "openid profile groups",
+    }
+
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    token = jwt.encode(payload, private_key_pem, algorithm="RS256")
+
+    # Mock admin user
+    mock_user = Mock()
+    mock_user.id = "user123"
+    mock_user.name = "Test User"
+    mock_user.is_owner = False
+    admin_group = Mock()
+    admin_group.id = "system-admin"
+    mock_user.groups = [admin_group]
+
+    mock_auth = Mock()
+    mock_auth.async_get_user = AsyncMock(return_value=mock_user)
+
+    hass = Mock()
+    hass.auth = mock_auth
+    hass.data = {
+        DOMAIN: {
+            "jwt_public_key": public_key,
+            "jwt_kid": "test-kid-1",
+            "clients": {"test_client": {}},
+        }
+    }
+
+    mock_url = Mock()
+    mock_url.origin.return_value = "http://localhost"
+
+    request = Mock()
+    request.app = {"hass": hass}
+    request.headers = {"Authorization": f"Bearer {token}"}
+    request.url = mock_url
+
+    from custom_components.oidc_provider.http import OIDCUserInfoView
+
+    view = OIDCUserInfoView()
+    response = await view.get(request)
+
+    assert response.status == 200
+    data = json.loads(response.body.decode("utf-8"))
+    assert data["groups"] == ["admin"]
+
+
+@pytest.mark.asyncio
+async def test_oidc_userinfo_groups_for_owner():
+    """Test UserInfo endpoint includes owner in groups for owner users."""
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    public_key = private_key.public_key()
+
+    payload = {
+        "sub": "owner123",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 3600,
+        "iss": "http://localhost",
+        "aud": "test_client",
+        "scope": "openid groups",
+    }
+
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    token = jwt.encode(payload, private_key_pem, algorithm="RS256")
+
+    # Mock owner user (owner is also in admin group)
+    mock_user = Mock()
+    mock_user.id = "owner123"
+    mock_user.name = "Owner User"
+    mock_user.is_owner = True
+    admin_group = Mock()
+    admin_group.id = "system-admin"
+    mock_user.groups = [admin_group]
+
+    mock_auth = Mock()
+    mock_auth.async_get_user = AsyncMock(return_value=mock_user)
+
+    hass = Mock()
+    hass.auth = mock_auth
+    hass.data = {
+        DOMAIN: {
+            "jwt_public_key": public_key,
+            "jwt_kid": "test-kid-1",
+            "clients": {"test_client": {}},
+        }
+    }
+
+    mock_url = Mock()
+    mock_url.origin.return_value = "http://localhost"
+
+    request = Mock()
+    request.app = {"hass": hass}
+    request.headers = {"Authorization": f"Bearer {token}"}
+    request.url = mock_url
+
+    from custom_components.oidc_provider.http import OIDCUserInfoView
+
+    view = OIDCUserInfoView()
+    response = await view.get(request)
+
+    assert response.status == 200
+    data = json.loads(response.body.decode("utf-8"))
+    assert data["groups"] == ["owner", "admin"]
+
+
+@pytest.mark.asyncio
+async def test_oidc_userinfo_groups_for_regular_user():
+    """Test UserInfo endpoint returns correct groups for regular user."""
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    public_key = private_key.public_key()
+
+    payload = {
+        "sub": "regular123",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 3600,
+        "iss": "http://localhost",
+        "aud": "test_client",
+        "scope": "openid groups",
+    }
+
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    token = jwt.encode(payload, private_key_pem, algorithm="RS256")
+
+    mock_user = Mock()
+    mock_user.id = "regular123"
+    mock_user.name = "Regular User"
+    mock_user.is_owner = False
+    user_group = Mock()
+    user_group.id = "system-users"
+    mock_user.groups = [user_group]
+
+    mock_auth = Mock()
+    mock_auth.async_get_user = AsyncMock(return_value=mock_user)
+
+    hass = Mock()
+    hass.auth = mock_auth
+    hass.data = {
+        DOMAIN: {
+            "jwt_public_key": public_key,
+            "jwt_kid": "test-kid-1",
+            "clients": {"test_client": {}},
+        }
+    }
+
+    mock_url = Mock()
+    mock_url.origin.return_value = "http://localhost"
+
+    request = Mock()
+    request.app = {"hass": hass}
+    request.headers = {"Authorization": f"Bearer {token}"}
+    request.url = mock_url
+
+    from custom_components.oidc_provider.http import OIDCUserInfoView
+
+    view = OIDCUserInfoView()
+    response = await view.get(request)
+
+    assert response.status == 200
+    data = json.loads(response.body.decode("utf-8"))
+    assert data["groups"] == ["user"]
+
+
+@pytest.mark.asyncio
+async def test_oidc_userinfo_groups_for_read_only_user():
+    """Test UserInfo endpoint returns correct groups for read-only user."""
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    public_key = private_key.public_key()
+
+    payload = {
+        "sub": "readonly123",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 3600,
+        "iss": "http://localhost",
+        "aud": "test_client",
+        "scope": "openid groups",
+    }
+
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    token = jwt.encode(payload, private_key_pem, algorithm="RS256")
+
+    mock_user = Mock()
+    mock_user.id = "readonly123"
+    mock_user.name = "Read Only User"
+    mock_user.is_owner = False
+    ro_group = Mock()
+    ro_group.id = "system-read-only"
+    mock_user.groups = [ro_group]
+
+    mock_auth = Mock()
+    mock_auth.async_get_user = AsyncMock(return_value=mock_user)
+
+    hass = Mock()
+    hass.auth = mock_auth
+    hass.data = {
+        DOMAIN: {
+            "jwt_public_key": public_key,
+            "jwt_kid": "test-kid-1",
+            "clients": {"test_client": {}},
+        }
+    }
+
+    mock_url = Mock()
+    mock_url.origin.return_value = "http://localhost"
+
+    request = Mock()
+    request.app = {"hass": hass}
+    request.headers = {"Authorization": f"Bearer {token}"}
+    request.url = mock_url
+
+    from custom_components.oidc_provider.http import OIDCUserInfoView
+
+    view = OIDCUserInfoView()
+    response = await view.get(request)
+
+    assert response.status == 200
+    data = json.loads(response.body.decode("utf-8"))
+    assert data["groups"] == ["read-only"]
+
+
+@pytest.mark.asyncio
+async def test_oidc_userinfo_only_returns_sub_without_scopes():
+    """Test UserInfo endpoint only returns sub when no optional scopes requested."""
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    public_key = private_key.public_key()
+
+    payload = {
+        "sub": "user123",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 3600,
+        "iss": "http://localhost",
+        "aud": "test_client",
+        "scope": "openid",
+    }
+
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    token = jwt.encode(payload, private_key_pem, algorithm="RS256")
+
+    mock_user = Mock()
+    mock_user.id = "user123"
+    mock_user.name = "Test User"
+    mock_user.is_owner = False
+    admin_group = Mock()
+    admin_group.id = "system-admin"
+    mock_user.groups = [admin_group]
+
+    mock_auth = Mock()
+    mock_auth.async_get_user = AsyncMock(return_value=mock_user)
+
+    hass = Mock()
+    hass.auth = mock_auth
+    hass.data = {
+        DOMAIN: {
+            "jwt_public_key": public_key,
+            "jwt_kid": "test-kid-1",
+            "clients": {"test_client": {}},
+        }
+    }
+
+    mock_url = Mock()
+    mock_url.origin.return_value = "http://localhost"
+
+    request = Mock()
+    request.app = {"hass": hass}
+    request.headers = {"Authorization": f"Bearer {token}"}
+    request.url = mock_url
+
+    from custom_components.oidc_provider.http import OIDCUserInfoView
+
+    view = OIDCUserInfoView()
+    response = await view.get(request)
+
+    assert response.status == 200
+    data = json.loads(response.body.decode("utf-8"))
+    assert data["sub"] == "user123"
+    assert "name" not in data
+    assert "email" not in data
+    assert "groups" not in data
+
+
+@pytest.mark.asyncio
+async def test_oidc_userinfo_returns_email_when_username_is_email():
+    """Test UserInfo endpoint returns email when username looks like an email address."""
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    public_key = private_key.public_key()
+
+    payload = {
+        "sub": "user123",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 3600,
+        "iss": "http://localhost",
+        "aud": "test_client",
+        "scope": "openid email",
+    }
+
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    token = jwt.encode(payload, private_key_pem, algorithm="RS256")
+
+    mock_user = Mock()
+    mock_user.id = "user123"
+    mock_user.name = "john@example.com"
+    mock_user.is_owner = False
+    mock_user.groups = []
+
+    mock_auth = Mock()
+    mock_auth.async_get_user = AsyncMock(return_value=mock_user)
+
+    hass = Mock()
+    hass.auth = mock_auth
+    hass.data = {
+        DOMAIN: {
+            "jwt_public_key": public_key,
+            "jwt_kid": "test-kid-1",
+            "clients": {"test_client": {}},
+        }
+    }
+
+    mock_url = Mock()
+    mock_url.origin.return_value = "http://localhost"
+
+    request = Mock()
+    request.app = {"hass": hass}
+    request.headers = {"Authorization": f"Bearer {token}"}
+    request.url = mock_url
+
+    from custom_components.oidc_provider.http import OIDCUserInfoView
+
+    view = OIDCUserInfoView()
+    response = await view.get(request)
+
+    assert response.status == 200
+    data = json.loads(response.body.decode("utf-8"))
+    assert data["email"] == "john@example.com"
+    assert data["email_verified"] is False
+
+
+@pytest.mark.asyncio
+async def test_oidc_authorize_rejects_missing_openid_scope():
+    """Test authorization endpoint rejects requests without openid scope."""
+    hass = Mock()
+    hass.data = {
+        DOMAIN: {
+            "clients": {
+                "test_client": {
+                    "redirect_uris": ["https://example.com/callback"],
+                }
+            },
+            "pending_auth_requests": {},
+            "require_pkce": False,
+        }
+    }
+
+    request = Mock()
+    request.app = {"hass": hass}
+    request.query = {
+        "client_id": "test_client",
+        "redirect_uri": "https://example.com/callback",
+        "response_type": "code",
+        "scope": "profile",
+    }
+
+    from custom_components.oidc_provider.http import OIDCAuthorizationView
+
+    view = OIDCAuthorizationView()
+    response = await view.get(request)
+
+    assert response.status == 400
+    assert b"openid scope is required" in response.body
+
+
+@pytest.mark.asyncio
+async def test_oidc_authorize_rejects_empty_scope():
+    """Test authorization endpoint rejects requests with empty scope."""
+    hass = Mock()
+    hass.data = {
+        DOMAIN: {
+            "clients": {
+                "test_client": {
+                    "redirect_uris": ["https://example.com/callback"],
+                }
+            },
+            "pending_auth_requests": {},
+            "require_pkce": False,
+        }
+    }
+
+    request = Mock()
+    request.app = {"hass": hass}
+    request.query = {
+        "client_id": "test_client",
+        "redirect_uri": "https://example.com/callback",
+        "response_type": "code",
+    }
+
+    from custom_components.oidc_provider.http import OIDCAuthorizationView
+
+    view = OIDCAuthorizationView()
+    response = await view.get(request)
+
+    assert response.status == 400
+    assert b"openid scope is required" in response.body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add support for the `groups` scope that exposes Home Assistant user groups (`owner`, `admin`, `user`, `read-only`) in the `groups` claim on both the access token and userinfo endpoint.

Also improves OIDC spec compliance:
- The `openid` scope is now validated as required on the authorize endpoint
- Claims are scope-gated: `name` requires `profile`, `email` requires `email`, `groups` requires `groups`
- The `email` claim is only returned when the HA username looks like an email address (instead of falling back to the user UUID)
- Returns `email_verified: false` alongside the `email` claim
- Discovery endpoint updated with new claims and scopes

**Breaking changes:**
- Clients that omit the `openid` scope will now receive a 400 error on `/oidc/authorize`
- `name` is no longer returned from `/oidc/userinfo` unless the `profile` scope is requested
- `email` is no longer returned from `/oidc/userinfo` unless the `email` scope is requested and the username looks like an email address (previously fell back to user UUID)

Bumps version to 1.3.0.

Closes #19