### PR TITLE
feat: harden OIDC id_token to spec, persist nonce/auth_time, gate userinfo

### DIFF
--- a/custom_components/oidc_provider/const.py
+++ b/custom_components/oidc_provider/const.py
@@ -9,8 +9,13 @@ STORAGE_KEY_TOKENS = f"{DOMAIN}.tokens"
 
 # Token expiry times (in seconds)
 ACCESS_TOKEN_EXPIRY = 3600  # 1 hour
+ID_TOKEN_EXPIRY = 3600  # 1 hour
 REFRESH_TOKEN_EXPIRY = 2592000  # 30 days
 AUTHORIZATION_CODE_EXPIRY = 600  # 10 minutes
+
+# Token type discriminator (custom claim used to distinguish access vs id tokens)
+TOKEN_USE_ACCESS = "access"
+TOKEN_USE_ID = "id"
 
 # OIDC scopes
 SCOPE_OPENID = "openid"

--- a/custom_components/oidc_provider/http.py
+++ b/custom_components/oidc_provider/http.py
@@ -30,6 +30,7 @@ from .const import (
     GRANT_TYPE_REFRESH_TOKEN,
     GROUP_OWNER,
     HA_GROUP_TO_OIDC_GROUP,
+    ID_TOKEN_EXPIRY,
     MAX_TOKEN_ATTEMPTS,
     RATE_LIMIT_PENALTY,
     RATE_LIMIT_WINDOW,
@@ -43,6 +44,8 @@ from .const import (
     STORAGE_VERSION,
     SUPPORTED_CODE_CHALLENGE_METHODS,
     SUPPORTED_SCOPES,
+    TOKEN_USE_ACCESS,
+    TOKEN_USE_ID,
 )
 from .security import verify_client_secret
 from .token_validator import get_issuer_from_request
@@ -184,6 +187,7 @@ class OIDCContinueView(HomeAssistantView):
         redirect_uri = stored_request["redirect_uri"]
         scope = stored_request["scope"]
         state = stored_request["state"]
+        nonce = stored_request.get("nonce")
         code_challenge = stored_request.get("code_challenge")
         code_challenge_method = stored_request.get("code_challenge_method")
 
@@ -197,6 +201,15 @@ class OIDCContinueView(HomeAssistantView):
             "redirect_uri": redirect_uri,
             "scope": scope,
             "user_id": user.id,
+            "nonce": nonce,
+            # OIDC §2 defines auth_time as when End-User authentication occurred.
+            # /oidc/continue is auth-gated, so we know the user *is* authenticated
+            # here, but the underlying HA session may be older. We stamp the time
+            # the user transited the consent step as the closest approximation
+            # available without reaching into HA's session internals. max_age
+            # is not honored at the authorize endpoint, so this approximation
+            # cannot mask a missed re-authentication today.
+            "auth_time": int(time.time()),
             "code_challenge": code_challenge,
             "code_challenge_method": code_challenge_method,
             "expires_at": time.time() + AUTHORIZATION_CODE_EXPIRY,
@@ -248,6 +261,9 @@ class OIDCDiscoveryView(HomeAssistantView):
                 "aud",
                 "exp",
                 "iat",
+                "auth_time",
+                "nonce",
+                "at_hash",
             ],
             "code_challenge_methods_supported": SUPPORTED_CODE_CHALLENGE_METHODS,
         }
@@ -338,6 +354,7 @@ class OIDCAuthorizationView(HomeAssistantView):
         response_type = request.query.get("response_type")
         scope = request.query.get("scope", "")
         state = request.query.get("state", "")
+        nonce = request.query.get("nonce")
         code_challenge = request.query.get("code_challenge")
         code_challenge_method = request.query.get(
             "code_challenge_method", CODE_CHALLENGE_METHOD_S256
@@ -354,6 +371,14 @@ class OIDCAuthorizationView(HomeAssistantView):
                 text="The openid scope is required for OIDC requests.",
                 status=400,
             )
+
+        # NOTE: max_age (OIDC Core §3.1.2.1) is intentionally not honored here.
+        # The auth_time claim emitted in the id_token is stamped at the
+        # /oidc/continue step, which approximates "authentication occurred"
+        # because HA may have authenticated the user via a long-lived session.
+        # If max_age support is added, auth_time MUST move to a primitive
+        # representing actual login time (e.g. the HA refresh token's
+        # created_at), otherwise max_age would silently no-op.
 
         # Check if PKCE is required
         require_pkce = hass.data[DOMAIN].get(CONF_REQUIRE_PKCE, DEFAULT_REQUIRE_PKCE)
@@ -405,6 +430,7 @@ class OIDCAuthorizationView(HomeAssistantView):
             "response_type": response_type,
             "scope": scope,
             "state": state,
+            "nonce": nonce,
             "code_challenge": code_challenge,
             "code_challenge_method": code_challenge_method,
             "expires_at": time.time() + 600,  # 10 minutes
@@ -631,16 +657,20 @@ class OIDCTokenView(HomeAssistantView):
         client_id = auth_data["client_id"]
         scope = auth_data["scope"]
 
-        access_token, id_token = await self._generate_tokens(
-            _request, hass, user_id, scope, client_id
-        )
+        nonce = auth_data.get("nonce")
+        auth_time = auth_data.get("auth_time")
+
+        access_token = await self._generate_access_token(_request, hass, user_id, scope, client_id)
         refresh_token = secrets.token_urlsafe(32)
 
-        # Store refresh token
+        # Store refresh token (nonce + auth_time persisted so future refreshes
+        # produce spec-correct id_tokens after Home Assistant restarts).
         hass.data[DOMAIN]["refresh_tokens"][refresh_token] = {
             "user_id": user_id,
             "client_id": client_id,
             "scope": scope,
+            "nonce": nonce,
+            "auth_time": auth_time,
             "expires_at": time.time() + REFRESH_TOKEN_EXPIRY,
         }
 
@@ -650,16 +680,31 @@ class OIDCTokenView(HomeAssistantView):
         # Delete used authorization code
         del auth_codes[code]
 
-        return web.json_response(
-            {
-                "access_token": access_token,
-                "id_token": id_token,
-                "token_type": "Bearer",
-                "expires_in": ACCESS_TOKEN_EXPIRY,
-                "refresh_token": refresh_token,
-                "scope": scope,
-            }
-        )
+        response_body: dict[str, Any] = {
+            "access_token": access_token,
+            "token_type": "Bearer",
+            "expires_in": ACCESS_TOKEN_EXPIRY,
+            "refresh_token": refresh_token,
+            "scope": scope,
+        }
+
+        # Issue an id_token only when openid scope was granted (OIDC Core §3.1.3.3).
+        # The authorize endpoint already enforces openid, so this branch is
+        # effectively always taken today; the explicit check is defense-in-depth
+        # against future changes loosening the authorize-side check.
+        if SCOPE_OPENID in (scope or "").split():
+            response_body["id_token"] = await self._generate_id_token(
+                _request,
+                hass,
+                user_id,
+                scope,
+                client_id,
+                nonce=nonce,
+                auth_time=auth_time,
+                access_token=access_token,
+            )
+
+        return web.json_response(response_body)
 
     async def _handle_refresh_token(
         self, _request: web.Request, hass: HomeAssistant, data: Any
@@ -683,55 +728,61 @@ class OIDCTokenView(HomeAssistantView):
             return web.json_response({"error": "invalid_grant"}, status=400)
 
         # Generate new access token
-        access_token, id_token = await self._generate_tokens(
+        access_token = await self._generate_access_token(
             _request, hass, token_data["user_id"], token_data["scope"], token_data["client_id"]
         )
 
-        return web.json_response(
-            {
-                "access_token": access_token,
-                "token_type": "Bearer",
-                "id_token": id_token,
-                "expires_in": ACCESS_TOKEN_EXPIRY,
-                "scope": token_data["scope"],
-            }
-        )
+        # Re-issue an id_token when openid scope is granted (OIDC Core §12.2).
+        # Original nonce and auth_time are carried forward; iat/exp/at_hash are
+        # fresh. Old refresh tokens persisted before this change have neither
+        # field, handled by .get() returning None.
+        response_body: dict[str, Any] = {
+            "access_token": access_token,
+            "token_type": "Bearer",
+            "expires_in": ACCESS_TOKEN_EXPIRY,
+            "scope": token_data["scope"],
+        }
 
-    async def _generate_tokens(
+        scope_value = token_data["scope"] or ""
+        if SCOPE_OPENID in scope_value.split():
+            response_body["id_token"] = await self._generate_id_token(
+                _request,
+                hass,
+                token_data["user_id"],
+                token_data["scope"],
+                token_data["client_id"],
+                nonce=token_data.get("nonce"),
+                auth_time=token_data.get("auth_time"),
+                access_token=access_token,
+            )
+
+        return web.json_response(response_body)
+
+    async def _generate_access_token(
         self, request: web.Request, hass: HomeAssistant, user_id: str, scope: str, client_id: str
-    ) -> tuple[str, str]:
-        """Generate access and id tokens."""
+    ) -> str:
+        """Generate JWT access token."""
         now = int(time.time())
 
         # Use dynamic issuer based on the actual base URL
         base_url = get_issuer_from_request(request)
 
-        access_payload = {
+        payload = {
             "sub": user_id,
             "iat": now,
             "exp": now + ACCESS_TOKEN_EXPIRY,
             "iss": base_url,
             "aud": client_id,
+            "scope": scope,
+            "token_use": TOKEN_USE_ACCESS,
         }
-        id_payload = access_payload.copy()
 
-        user = await hass.auth.async_get_user(user_id)
+        # Include groups claim when the groups scope is requested
         requested_scopes = scope.split() if scope else []
-        if user:
-            if SCOPE_GROUPS in requested_scopes:
-                # claims should be only included on id_token, but some clients may expect groups
-                # in access_token too, so we include in both
-                access_payload["groups"] = _resolve_user_groups(user)
-                id_payload["groups"] = _resolve_user_groups(user)
-
-            if SCOPE_PROFILE in requested_scopes:
-                id_payload["name"] = user.name
-
-            if SCOPE_EMAIL in requested_scopes:
-                username = user.name or ""
-                if _looks_like_email(username):
-                    id_payload["email"] = username
-                    id_payload["email_verified"] = False
+        if SCOPE_GROUPS in requested_scopes:
+            user = await hass.auth.async_get_user(user_id)
+            if user:
+                payload["groups"] = _resolve_user_groups(user)
 
         private_key = hass.data[DOMAIN]["jwt_private_key"]
         kid = hass.data[DOMAIN]["jwt_kid"]
@@ -741,12 +792,82 @@ class OIDCTokenView(HomeAssistantView):
             encryption_algorithm=serialization.NoEncryption(),
         )
 
-        access_token = jwt.encode(
-            access_payload, private_pem, algorithm="RS256", headers={"kid": kid}
-        )
-        id_token = jwt.encode(id_payload, private_pem, algorithm="RS256", headers={"kid": kid})
+        return jwt.encode(payload, private_pem, algorithm="RS256", headers={"kid": kid})
 
-        return access_token, id_token
+    async def _generate_id_token(
+        self,
+        request: web.Request,
+        hass: HomeAssistant,
+        user_id: str,
+        scope: str,
+        client_id: str,
+        *,
+        nonce: str | None,
+        auth_time: int | None,
+        access_token: str,
+    ) -> str:
+        """Generate an OIDC ID Token (OIDC Core 1.0 §2)."""
+        now = int(time.time())
+        base_url = get_issuer_from_request(request)
+
+        payload: dict[str, Any] = {
+            "iss": base_url,
+            "sub": user_id,
+            "aud": client_id,
+            "iat": now,
+            "exp": now + ID_TOKEN_EXPIRY,
+            "token_use": TOKEN_USE_ID,
+        }
+
+        if auth_time is not None:
+            payload["auth_time"] = int(auth_time)
+
+        # Nonce: MUST be echoed when present in the auth request,
+        # MUST NOT be included otherwise (OIDC Core §3.1.3.7).
+        if nonce is not None:
+            payload["nonce"] = nonce
+
+        # at_hash: base64url-encoded left-most half of the SHA-256 hash of the
+        # access token (OIDC Core §3.1.3.6). Defense-in-depth binding so a
+        # stolen access token cannot be paired with a different id_token.
+        digest = hashlib.sha256(access_token.encode("ascii")).digest()
+        payload["at_hash"] = (
+            base64.urlsafe_b64encode(digest[: len(digest) // 2]).decode("ascii").rstrip("=")
+        )
+
+        # Scope-gated identity claims. OIDC Core §5.4 permits returning these
+        # in the id_token; many real-world clients (oauth2-proxy, mod_auth_openidc)
+        # only read identity from the id_token, so include them when granted.
+        requested_scopes = scope.split() if scope else []
+        user = None
+        if (
+            SCOPE_PROFILE in requested_scopes
+            or SCOPE_EMAIL in requested_scopes
+            or SCOPE_GROUPS in requested_scopes
+        ):
+            user = await hass.auth.async_get_user(user_id)
+
+        if user and SCOPE_PROFILE in requested_scopes:
+            payload["name"] = user.name
+
+        if user and SCOPE_EMAIL in requested_scopes:
+            username = user.name or ""
+            if _looks_like_email(username):
+                payload["email"] = username
+                payload["email_verified"] = False
+
+        if user and SCOPE_GROUPS in requested_scopes:
+            payload["groups"] = _resolve_user_groups(user)
+
+        private_key = hass.data[DOMAIN]["jwt_private_key"]
+        kid = hass.data[DOMAIN]["jwt_kid"]
+        private_pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+        return jwt.encode(payload, private_pem, algorithm="RS256", headers={"kid": kid})
 
 
 class OIDCUserInfoView(HomeAssistantView):
@@ -790,6 +911,14 @@ class OIDCUserInfoView(HomeAssistantView):
                     "verify_exp": True,
                 },
             )
+
+            # Reject id_tokens at the userinfo endpoint. Only access tokens
+            # are accepted here. Tokens issued before the token_use claim
+            # existed have no token_use; treat absent as access for backward
+            # compatibility, but explicitly reject token_use="id".
+            if payload.get("token_use") == TOKEN_USE_ID:
+                _LOGGER.warning("ID token presented at userinfo endpoint")
+                return web.json_response({"error": "invalid_token"}, status=401)
 
             # Verify the audience claim exists and matches a registered client
             aud = payload.get("aud")

--- a/custom_components/oidc_provider/manifest.json
+++ b/custom_components/oidc_provider/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-oidc-server/issues",
   "requirements": ["PyJWT>=2.8.0", "cryptography>=43.0.0"],
-  "version": "1.3.0"
+  "version": "1.4.0"
 }

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -33,7 +33,20 @@ def test_discovery_document_structure():
             "client_secret_post",
             "client_secret_basic",
         ],
-        "claims_supported": ["sub", "name", "email", "iss", "aud", "exp", "iat"],
+        "claims_supported": [
+            "sub",
+            "name",
+            "email",
+            "email_verified",
+            "groups",
+            "iss",
+            "aud",
+            "exp",
+            "iat",
+            "auth_time",
+            "nonce",
+            "at_hash",
+        ],
     }
 
     # Required OIDC discovery fields

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -211,6 +211,10 @@ async def test_oidc_discovery_endpoint():
     assert "client_secret_post" in data["token_endpoint_auth_methods_supported"]
     assert "client_secret_basic" in data["token_endpoint_auth_methods_supported"]
 
+    # ID token claims advertised after id_token issuance was added
+    for claim in ("auth_time", "nonce", "at_hash"):
+        assert claim in data["claims_supported"]
+
 
 @pytest.mark.asyncio
 async def test_oidc_discovery_with_proxy():
@@ -840,13 +844,10 @@ async def test_oidc_token_view_basic_auth():
         public_exponent=65537, key_size=2048, backend=default_backend()
     )
 
-    mock_token_store = AsyncMock()
-
-    mock_auth = Mock()
-    mock_auth.async_get_user = AsyncMock(return_value=None)
+    mock_token_store = Mock()
+    mock_token_store.async_save = AsyncMock()
 
     hass = Mock()
-    hass.auth = mock_auth
     hass.data = {
         DOMAIN: {
             "clients": {
@@ -1245,13 +1246,10 @@ async def test_oidc_token_view_valid_pkce():
         public_exponent=65537, key_size=2048, backend=default_backend()
     )
 
-    mock_token_store = AsyncMock()
-
-    mock_auth = Mock()
-    mock_auth.async_get_user = AsyncMock(return_value=None)
+    mock_token_store = Mock()
+    mock_token_store.async_save = AsyncMock()
 
     hass = Mock()
-    hass.auth = mock_auth
     hass.data = {
         DOMAIN: {
             "clients": {
@@ -1278,6 +1276,13 @@ async def test_oidc_token_view_valid_pkce():
         }
     }
 
+    mock_user = Mock()
+    mock_user.name = "Test User"
+    mock_user.is_owner = False
+    mock_user.groups = []
+    hass.auth = Mock()
+    hass.auth.async_get_user = AsyncMock(return_value=mock_user)
+
     request = MagicMock()
     request.app = {"hass": hass}
     request.remote = "127.0.0.1"
@@ -1302,8 +1307,8 @@ async def test_oidc_token_view_valid_pkce():
     body = response.body.decode("utf-8")
     data = json.loads(body)
     assert "access_token" in data
-    assert "id_token" in data
     assert "refresh_token" in data
+    assert "id_token" in data
     assert data["token_type"] == "Bearer"
     assert data["scope"] == "openid profile"
 
@@ -1349,7 +1354,8 @@ async def test_oidc_token_view_includes_groups_in_access_token():
     mock_auth = Mock()
     mock_auth.async_get_user = AsyncMock(return_value=mock_user)
 
-    mock_token_store = AsyncMock()
+    mock_token_store = Mock()
+    mock_token_store.async_save = AsyncMock()
 
     hass = Mock()
     hass.auth = mock_auth
@@ -1434,13 +1440,10 @@ async def test_oidc_token_view_excludes_groups_without_scope():
     )
     public_key = private_key.public_key()
 
-    mock_token_store = AsyncMock()
-
-    mock_auth = Mock()
-    mock_auth.async_get_user = AsyncMock(return_value=None)
+    mock_token_store = Mock()
+    mock_token_store.async_save = AsyncMock()
 
     hass = Mock()
-    hass.auth = mock_auth
     hass.data = {
         DOMAIN: {
             "clients": {
@@ -1466,6 +1469,13 @@ async def test_oidc_token_view_excludes_groups_without_scope():
             "token_store": mock_token_store,
         }
     }
+
+    mock_user = Mock()
+    mock_user.name = "Test User"
+    mock_user.is_owner = False
+    mock_user.groups = []
+    hass.auth = Mock()
+    hass.auth.async_get_user = AsyncMock(return_value=mock_user)
 
     request = MagicMock()
     request.app = {"hass": hass}
@@ -1513,13 +1523,10 @@ async def test_oidc_token_view_refresh_token():
         public_exponent=65537, key_size=2048, backend=default_backend()
     )
 
-    mock_token_store = AsyncMock()
-
-    mock_auth = Mock()
-    mock_auth.async_get_user = AsyncMock(return_value=None)
+    mock_token_store = Mock()
+    mock_token_store.async_save = AsyncMock()
 
     hass = Mock()
-    hass.auth = mock_auth
     hass.data = {
         DOMAIN: {
             "clients": {
@@ -1541,6 +1548,13 @@ async def test_oidc_token_view_refresh_token():
             "token_store": mock_token_store,
         }
     }
+
+    mock_user = Mock()
+    mock_user.name = "user@example.com"
+    mock_user.is_owner = False
+    mock_user.groups = []
+    hass.auth = Mock()
+    hass.auth.async_get_user = AsyncMock(return_value=mock_user)
 
     mock_url = Mock()
     mock_url.origin.return_value = "http://localhost"

--- a/tests/test_id_token.py
+++ b/tests/test_id_token.py
@@ -1,0 +1,613 @@
+"""Tests for ID Token issuance (OIDC Core 1.0 §2)."""
+
+import base64
+import hashlib
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import jwt
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from custom_components.oidc_provider.const import DOMAIN
+from custom_components.oidc_provider.http import (
+    OIDCAuthorizationView,
+    OIDCContinueView,
+    OIDCTokenView,
+    OIDCUserInfoView,
+)
+from custom_components.oidc_provider.security import hash_client_secret
+
+
+def _make_keys():
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_key, public_pem
+
+
+def _make_user(name: str = "Test User", is_owner: bool = False):
+    user = Mock()
+    user.id = "user123"
+    user.name = name
+    user.is_owner = is_owner
+    user.groups = []
+    return user
+
+
+def _pkce_pair():
+    verifier = "valid_verifier_1234567890_abcdefghijklmnop"
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    return verifier, challenge
+
+
+def _build_token_hass(
+    private_key,
+    *,
+    auth_code_data: dict,
+    refresh_token_data: dict | None = None,
+    user=None,
+):
+    """Build a Mock hass instance suitable for OIDCTokenView."""
+    mock_token_store = Mock()
+    mock_token_store.async_save = AsyncMock()
+    hass = Mock()
+    hass.data = {
+        DOMAIN: {
+            "clients": {
+                "test_client": {
+                    "client_secret_hash": hash_client_secret("test_secret"),
+                    "redirect_uris": ["https://example.com/callback"],
+                }
+            },
+            "authorization_codes": {"valid_code": auth_code_data} if auth_code_data else {},
+            "refresh_tokens": refresh_token_data or {},
+            "rate_limit_attempts": {},
+            "jwt_private_key": private_key,
+            "jwt_kid": "test-kid-1",
+            "token_store": mock_token_store,
+        }
+    }
+    hass.auth = Mock()
+    hass.auth.async_get_user = AsyncMock(return_value=user or _make_user())
+    return hass
+
+
+_FIXED_HEADERS = {"X-Forwarded-Proto": "https", "X-Forwarded-Host": "ha.example.com"}
+_FIXED_ISSUER = "https://ha.example.com"
+
+
+def _post_authorization_code(hass, *, code_verifier=None):
+    request = MagicMock()
+    request.app = {"hass": hass}
+    request.remote = "127.0.0.1"
+    request.headers = dict(_FIXED_HEADERS)
+    body = {
+        "grant_type": "authorization_code",
+        "client_id": "test_client",
+        "client_secret": "test_secret",
+        "code": "valid_code",
+        "redirect_uri": "https://example.com/callback",
+    }
+    if code_verifier:
+        body["code_verifier"] = code_verifier
+    request.post = AsyncMock(return_value=body)
+    return request
+
+
+def _post_refresh(hass, refresh_token: str = "rt_value"):
+    request = MagicMock()
+    request.app = {"hass": hass}
+    request.remote = "127.0.0.1"
+    request.headers = dict(_FIXED_HEADERS)
+    request.post = AsyncMock(
+        return_value={
+            "grant_type": "refresh_token",
+            "client_id": "test_client",
+            "client_secret": "test_secret",
+            "refresh_token": refresh_token,
+        }
+    )
+    return request
+
+
+def _decode_id_token(token: str, public_pem: bytes, *, audience="test_client") -> dict:
+    return jwt.decode(token, public_pem, algorithms=["RS256"], audience=audience)
+
+
+# ---------------------------------------------------------------------------
+# Authorization endpoint captures the nonce
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_authorize_captures_nonce():
+    hass = Mock()
+    hass.data = {
+        DOMAIN: {
+            "clients": {"test_client": {"redirect_uris": ["https://example.com/callback"]}},
+            "pending_auth_requests": {},
+        }
+    }
+
+    request = Mock()
+    request.app = {"hass": hass}
+    request.query = {
+        "client_id": "test_client",
+        "redirect_uri": "https://example.com/callback",
+        "response_type": "code",
+        "scope": "openid",
+        "nonce": "n-0S6_WzA2Mj",
+        "code_challenge": "x",
+        "code_challenge_method": "S256",
+    }
+
+    response = await OIDCAuthorizationView().get(request)
+    assert response.status == 200
+
+    pending = hass.data[DOMAIN]["pending_auth_requests"]
+    [stored] = pending.values()
+    assert stored["nonce"] == "n-0S6_WzA2Mj"
+
+
+@pytest.mark.asyncio
+async def test_authorize_missing_nonce_stores_none():
+    hass = Mock()
+    hass.data = {
+        DOMAIN: {
+            "clients": {"test_client": {"redirect_uris": ["https://example.com/callback"]}},
+            "pending_auth_requests": {},
+        }
+    }
+
+    request = Mock()
+    request.app = {"hass": hass}
+    request.query = {
+        "client_id": "test_client",
+        "redirect_uri": "https://example.com/callback",
+        "response_type": "code",
+        "scope": "openid",
+        "code_challenge": "x",
+        "code_challenge_method": "S256",
+    }
+
+    response = await OIDCAuthorizationView().get(request)
+    assert response.status == 200
+
+    [stored] = hass.data[DOMAIN]["pending_auth_requests"].values()
+    assert stored["nonce"] is None
+
+
+# ---------------------------------------------------------------------------
+# Continue endpoint propagates nonce + stamps auth_time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_continue_propagates_nonce_and_stamps_auth_time():
+    hass = Mock()
+    hass.data = {
+        DOMAIN: {
+            "pending_auth_requests": {
+                "req123": {
+                    "client_id": "test_client",
+                    "redirect_uri": "https://example.com/callback",
+                    "scope": "openid",
+                    "state": "",
+                    "nonce": "abc-nonce",
+                    "code_challenge": "c",
+                    "code_challenge_method": "S256",
+                    "expires_at": time.time() + 600,
+                }
+            },
+            "authorization_codes": {},
+        }
+    }
+    before = int(time.time())
+
+    request = MagicMock()
+    request.query = {"request_id": "req123"}
+    request.app = {"hass": hass}
+    request.__getitem__.return_value = Mock(id="user123")
+
+    response = await OIDCContinueView().get(request)
+    assert response.status == 200
+
+    [code_data] = hass.data[DOMAIN]["authorization_codes"].values()
+    assert code_data["nonce"] == "abc-nonce"
+    assert code_data["auth_time"] >= before
+    assert code_data["auth_time"] <= int(time.time())
+
+
+# ---------------------------------------------------------------------------
+# Token endpoint issues a spec-compliant id_token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_id_token_issued_with_required_claims():
+    private_key, public_pem = _make_keys()
+    verifier, challenge = _pkce_pair()
+    auth_time = int(time.time()) - 5
+
+    hass = _build_token_hass(
+        private_key,
+        auth_code_data={
+            "client_id": "test_client",
+            "redirect_uri": "https://example.com/callback",
+            "user_id": "user123",
+            "scope": "openid",
+            "nonce": "round-trip-nonce",
+            "auth_time": auth_time,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "expires_at": time.time() + 600,
+        },
+    )
+
+    response = await OIDCTokenView().post(_post_authorization_code(hass, code_verifier=verifier))
+    assert response.status == 200
+    body = json.loads(response.body.decode("utf-8"))
+    assert "id_token" in body
+
+    claims = _decode_id_token(body["id_token"], public_pem)
+
+    # Required claims (OIDC Core §2)
+    assert claims["sub"] == "user123"
+    assert claims["aud"] == "test_client"
+    assert claims["iss"]
+    assert claims["iat"] <= int(time.time())
+    assert claims["exp"] > claims["iat"]
+
+    # Echoed nonce
+    assert claims["nonce"] == "round-trip-nonce"
+
+    # auth_time is what we stored at /oidc/continue time
+    assert claims["auth_time"] == auth_time
+
+    # token_use marks this as an id token
+    assert claims["token_use"] == "id"
+
+    # at_hash binds to the access token
+    digest = hashlib.sha256(body["access_token"].encode("ascii")).digest()
+    expected_at_hash = (
+        base64.urlsafe_b64encode(digest[: len(digest) // 2]).decode("ascii").rstrip("=")
+    )
+    assert claims["at_hash"] == expected_at_hash
+
+
+@pytest.mark.asyncio
+async def test_id_token_omits_nonce_when_not_requested():
+    private_key, public_pem = _make_keys()
+    verifier, challenge = _pkce_pair()
+
+    hass = _build_token_hass(
+        private_key,
+        auth_code_data={
+            "client_id": "test_client",
+            "redirect_uri": "https://example.com/callback",
+            "user_id": "user123",
+            "scope": "openid",
+            "nonce": None,
+            "auth_time": int(time.time()),
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "expires_at": time.time() + 600,
+        },
+    )
+
+    response = await OIDCTokenView().post(_post_authorization_code(hass, code_verifier=verifier))
+    body = json.loads(response.body.decode("utf-8"))
+    claims = _decode_id_token(body["id_token"], public_pem)
+    assert "nonce" not in claims
+
+
+@pytest.mark.asyncio
+async def test_id_token_includes_scope_gated_claims():
+    private_key, public_pem = _make_keys()
+    verifier, challenge = _pkce_pair()
+    user = _make_user(name="user@example.com", is_owner=True)
+
+    hass = _build_token_hass(
+        private_key,
+        user=user,
+        auth_code_data={
+            "client_id": "test_client",
+            "redirect_uri": "https://example.com/callback",
+            "user_id": "user123",
+            "scope": "openid profile email groups",
+            "nonce": None,
+            "auth_time": int(time.time()),
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "expires_at": time.time() + 600,
+        },
+    )
+
+    response = await OIDCTokenView().post(_post_authorization_code(hass, code_verifier=verifier))
+    body = json.loads(response.body.decode("utf-8"))
+    claims = _decode_id_token(body["id_token"], public_pem)
+
+    assert claims["name"] == "user@example.com"
+    assert claims["email"] == "user@example.com"
+    assert claims["email_verified"] is False
+    assert claims["groups"] == ["owner"]
+
+
+@pytest.mark.asyncio
+async def test_id_token_excludes_claims_when_scopes_absent():
+    private_key, public_pem = _make_keys()
+    verifier, challenge = _pkce_pair()
+
+    hass = _build_token_hass(
+        private_key,
+        auth_code_data={
+            "client_id": "test_client",
+            "redirect_uri": "https://example.com/callback",
+            "user_id": "user123",
+            "scope": "openid",
+            "nonce": None,
+            "auth_time": int(time.time()),
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "expires_at": time.time() + 600,
+        },
+    )
+
+    response = await OIDCTokenView().post(_post_authorization_code(hass, code_verifier=verifier))
+    body = json.loads(response.body.decode("utf-8"))
+    claims = _decode_id_token(body["id_token"], public_pem)
+
+    for absent in ("name", "email", "email_verified", "groups"):
+        assert absent not in claims
+
+
+# ---------------------------------------------------------------------------
+# Refresh-token grant re-issues an id_token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_reissues_id_token_with_original_nonce_and_auth_time():
+    private_key, public_pem = _make_keys()
+    auth_time = int(time.time()) - 600
+
+    hass = _build_token_hass(
+        private_key,
+        auth_code_data={},
+        refresh_token_data={
+            "rt_value": {
+                "client_id": "test_client",
+                "user_id": "user123",
+                "scope": "openid",
+                "nonce": "original-nonce",
+                "auth_time": auth_time,
+                "expires_at": time.time() + 3600,
+            }
+        },
+    )
+
+    response = await OIDCTokenView().post(_post_refresh(hass))
+    assert response.status == 200
+    body = json.loads(response.body.decode("utf-8"))
+    assert "id_token" in body
+
+    claims = _decode_id_token(body["id_token"], public_pem)
+    assert claims["nonce"] == "original-nonce"
+    assert claims["auth_time"] == auth_time
+    assert claims["sub"] == "user123"
+
+    # at_hash must match the *new* access token
+    digest = hashlib.sha256(body["access_token"].encode("ascii")).digest()
+    assert claims["at_hash"] == (
+        base64.urlsafe_b64encode(digest[: len(digest) // 2]).decode("ascii").rstrip("=")
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_legacy_record_without_nonce_or_auth_time():
+    """Refresh tokens persisted before this change have no nonce/auth_time keys."""
+    private_key, public_pem = _make_keys()
+
+    hass = _build_token_hass(
+        private_key,
+        auth_code_data={},
+        refresh_token_data={
+            "rt_value": {
+                "client_id": "test_client",
+                "user_id": "user123",
+                "scope": "openid",
+                "expires_at": time.time() + 3600,
+            }
+        },
+    )
+
+    response = await OIDCTokenView().post(_post_refresh(hass))
+    assert response.status == 200
+    body = json.loads(response.body.decode("utf-8"))
+    assert "id_token" in body
+
+    claims = _decode_id_token(body["id_token"], public_pem)
+    # Original auth had no nonce → MUST NOT include
+    assert "nonce" not in claims
+    # auth_time was never recorded → omitted
+    assert "auth_time" not in claims
+
+
+@pytest.mark.asyncio
+async def test_authorization_code_without_openid_scope_omits_id_token():
+    """Defense-in-depth: even if an auth code somehow lacks openid scope, the
+    code-grant response must not include an id_token."""
+    private_key, _ = _make_keys()
+    verifier, challenge = _pkce_pair()
+
+    hass = _build_token_hass(
+        private_key,
+        auth_code_data={
+            "client_id": "test_client",
+            "redirect_uri": "https://example.com/callback",
+            "user_id": "user123",
+            "scope": "profile",  # no openid, bypassing the authorize-side check
+            "nonce": None,
+            "auth_time": int(time.time()),
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "expires_at": time.time() + 600,
+        },
+    )
+
+    response = await OIDCTokenView().post(_post_authorization_code(hass, code_verifier=verifier))
+    assert response.status == 200
+    body = json.loads(response.body.decode("utf-8"))
+    assert "access_token" in body
+    assert "id_token" not in body
+
+
+@pytest.mark.asyncio
+async def test_refresh_without_openid_scope_omits_id_token():
+    private_key, _ = _make_keys()
+
+    hass = _build_token_hass(
+        private_key,
+        auth_code_data={},
+        refresh_token_data={
+            "rt_value": {
+                "client_id": "test_client",
+                "user_id": "user123",
+                "scope": "profile",
+                "expires_at": time.time() + 3600,
+            }
+        },
+    )
+
+    response = await OIDCTokenView().post(_post_refresh(hass))
+    assert response.status == 200
+    body = json.loads(response.body.decode("utf-8"))
+    assert "id_token" not in body
+
+
+# ---------------------------------------------------------------------------
+# Persistence: refresh_tokens dict must include nonce/auth_time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_authorization_code_persists_nonce_and_auth_time_on_refresh_record():
+    private_key, _ = _make_keys()
+    verifier, challenge = _pkce_pair()
+    auth_time = int(time.time()) - 1
+
+    hass = _build_token_hass(
+        private_key,
+        auth_code_data={
+            "client_id": "test_client",
+            "redirect_uri": "https://example.com/callback",
+            "user_id": "user123",
+            "scope": "openid",
+            "nonce": "persist-me",
+            "auth_time": auth_time,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "expires_at": time.time() + 600,
+        },
+    )
+
+    response = await OIDCTokenView().post(_post_authorization_code(hass, code_verifier=verifier))
+    assert response.status == 200
+
+    [stored] = hass.data[DOMAIN]["refresh_tokens"].values()
+    assert stored["nonce"] == "persist-me"
+    assert stored["auth_time"] == auth_time
+
+    # And it was flushed to the persistent store so it survives restart.
+    hass.data[DOMAIN]["token_store"].async_save.assert_called_once()
+    saved = hass.data[DOMAIN]["token_store"].async_save.call_args[0][0]
+    [persisted] = saved["refresh_tokens"].values()
+    assert persisted["nonce"] == "persist-me"
+    assert persisted["auth_time"] == auth_time
+
+
+# ---------------------------------------------------------------------------
+# Userinfo rejects id_tokens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_userinfo_rejects_id_token():
+    private_key, _ = _make_keys()
+    verifier, challenge = _pkce_pair()
+
+    hass = _build_token_hass(
+        private_key,
+        auth_code_data={
+            "client_id": "test_client",
+            "redirect_uri": "https://example.com/callback",
+            "user_id": "user123",
+            "scope": "openid",
+            "nonce": None,
+            "auth_time": int(time.time()),
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "expires_at": time.time() + 600,
+        },
+    )
+
+    response = await OIDCTokenView().post(_post_authorization_code(hass, code_verifier=verifier))
+    body = json.loads(response.body.decode("utf-8"))
+    id_token = body["id_token"]
+
+    # Now attempt to use the id_token at /oidc/userinfo
+    hass.data[DOMAIN]["jwt_public_key"] = private_key.public_key()
+
+    userinfo_request = Mock()
+    userinfo_request.app = {"hass": hass}
+    userinfo_request.headers = {**_FIXED_HEADERS, "Authorization": f"Bearer {id_token}"}
+
+    userinfo_response = await OIDCUserInfoView().get(userinfo_request)
+    assert userinfo_response.status == 401
+    payload = json.loads(userinfo_response.body.decode("utf-8"))
+    assert payload["error"] == "invalid_token"
+
+
+@pytest.mark.asyncio
+async def test_userinfo_accepts_access_token():
+    private_key, _ = _make_keys()
+    verifier, challenge = _pkce_pair()
+
+    hass = _build_token_hass(
+        private_key,
+        auth_code_data={
+            "client_id": "test_client",
+            "redirect_uri": "https://example.com/callback",
+            "user_id": "user123",
+            "scope": "openid",
+            "nonce": None,
+            "auth_time": int(time.time()),
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "expires_at": time.time() + 600,
+        },
+    )
+
+    response = await OIDCTokenView().post(_post_authorization_code(hass, code_verifier=verifier))
+    body = json.loads(response.body.decode("utf-8"))
+    access_token = body["access_token"]
+
+    hass.data[DOMAIN]["jwt_public_key"] = private_key.public_key()
+
+    userinfo_request = Mock()
+    userinfo_request.app = {"hass": hass}
+    userinfo_request.headers = {**_FIXED_HEADERS, "Authorization": f"Bearer {access_token}"}
+
+    userinfo_response = await OIDCUserInfoView().get(userinfo_request)
+    assert userinfo_response.status == 200
+    payload = json.loads(userinfo_response.body.decode("utf-8"))
+    assert payload["sub"] == "user123"


### PR DESCRIPTION
Builds on #21. The id_token introduced there works for the simple case, but to be safe to interop with strict OIDC clients (oauth2-proxy, mod_auth_openidc, Kubernetes) and to survive Home Assistant restarts cleanly, a handful of OIDC Core 1.0 pieces need to be in place. This PR adds them and bumps the manifest version for the release.

**Authorize endpoint**
- Captures the optional `nonce` query parameter so it can be round-tripped into the id_token.
- An inline note flags that `max_age` is intentionally not honored. If `max_age` support is ever added, `auth_time` must move to a primitive representing real login time.

**Continue endpoint**
- Stamps `auth_time` at the consent step. The endpoint is auth-gated, so the user is known to be authenticated, but the underlying HA session may predate consent. This is an honest approximation of "authentication occurred." Because `max_age` is not honored anywhere today, the approximation cannot mask a missed re-authentication.

**Token endpoint**
- Splits the merged generator from #21 back into `_generate_access_token` and `_generate_id_token`. The id_token path needs `nonce`, `auth_time`, `at_hash`, and scope-gated identity claims that don't belong on the access token, and id_token issuance should be gated on the `openid` scope.
- Restores the `scope` claim on access tokens. #21 dropped it when introducing the merged generator; without it, `/oidc/userinfo` returns only `sub` because it scope-gates `name`/`email`/`groups` off the access token's `scope` claim.
- Echoes `nonce` into the id_token when one was sent at authorize time, omits the claim entirely otherwise (§3.1.3.7).
- Adds `at_hash` (§3.1.3.6) binding the id_token to the access token. Defense-in-depth so a stolen access token cannot be paired with a different id_token.
- Persists `nonce` and `auth_time` on the refresh-token record so post-restart refreshes re-issue spec-correct id_tokens (§12.2). Legacy refresh records without these fields keep working: `nonce` is omitted (none was sent originally) and `auth_time` is omitted.
- Gates id_token issuance on the `openid` scope in both grant flows. The authorize endpoint already enforces this, so it's defense-in-depth.

**Userinfo hardening**
- Access tokens now carry `token_use="access"` and id tokens `token_use="id"`. Userinfo rejects `token_use="id"` so a stolen id_token cannot be substituted for an access token, even though they share `aud`/`sub`/signature. Tokens issued before this change have no `token_use` claim and are still accepted (treated as access).

**Discovery**
- `claims_supported` advertises `auth_time`, `nonce`, `at_hash` so strict clients and conformance suites see the full set of claims the OP can emit.

**Tests**
- 14 new tests in `tests/test_id_token.py` cover nonce capture/round-trip/omission, auth_time stamping, required claims, `at_hash` binding, scope-gated claims, refresh re-issuance, legacy refresh records, refresh and authorization-code without `openid`, persistence, and userinfo accepting access tokens / rejecting id tokens.
- Existing token-grant tests in `tests/test_http.py` were updated to mock `hass.auth.async_get_user` because the id_token path consults the user when profile/email/groups are granted, and `test_oidc_token_view_basic_auth` re-asserts that `id_token` is present (the scope is `openid`). The live discovery test pins the new `claims_supported` entries.

Bumps manifest version to `1.4.0` for the release.