### PR TITLE
fix: suffix OIDC issuer with /oidc for RFC 8414 compliance

### DIFF
--- a/custom_components/oidc_provider/http.py
+++ b/custom_components/oidc_provider/http.py
@@ -237,7 +237,7 @@ class OIDCDiscoveryView(HomeAssistantView):
         base_url = get_issuer_from_request(request)
 
         discovery = {
-            "issuer": base_url,
+            "issuer": f"{base_url}/oidc",
             "authorization_endpoint": f"{base_url}/oidc/authorize",
             "token_endpoint": f"{base_url}/oidc/token",
             "userinfo_endpoint": f"{base_url}/oidc/userinfo",
@@ -283,7 +283,7 @@ class OAuth2AuthorizationServerMetadataView(HomeAssistantView):
         base_url = get_issuer_from_request(request)
 
         metadata = {
-            "issuer": base_url,
+            "issuer": f"{base_url}/oidc",
             "authorization_endpoint": f"{base_url}/oidc/authorize",
             "token_endpoint": f"{base_url}/oidc/token",
             "registration_endpoint": f"{base_url}/oidc/register",
@@ -319,7 +319,7 @@ class OAuth2AuthorizationServerMetadataAlternateView(HomeAssistantView):
         base_url = get_issuer_from_request(request)
 
         metadata = {
-            "issuer": base_url,
+            "issuer": f"{base_url}/oidc",
             "authorization_endpoint": f"{base_url}/oidc/authorize",
             "token_endpoint": f"{base_url}/oidc/token",
             "registration_endpoint": f"{base_url}/oidc/register",
@@ -764,14 +764,18 @@ class OIDCTokenView(HomeAssistantView):
         """Generate JWT access token."""
         now = int(time.time())
 
-        # Use dynamic issuer based on the actual base URL
+        # Use dynamic issuer based on the actual base URL. The /oidc suffix is
+        # required by RFC 8414: the issuer URL concatenated with
+        # /.well-known/oauth-authorization-server must return the auth-server
+        # metadata, and that metadata lives under /oidc.
         base_url = get_issuer_from_request(request)
+        issuer = f"{base_url}/oidc"
 
         payload = {
             "sub": user_id,
             "iat": now,
             "exp": now + ACCESS_TOKEN_EXPIRY,
-            "iss": base_url,
+            "iss": issuer,
             "aud": client_id,
             "scope": scope,
             "token_use": TOKEN_USE_ACCESS,
@@ -809,9 +813,10 @@ class OIDCTokenView(HomeAssistantView):
         """Generate an OIDC ID Token (OIDC Core 1.0 §2)."""
         now = int(time.time())
         base_url = get_issuer_from_request(request)
+        issuer = f"{base_url}/oidc"
 
         payload: dict[str, Any] = {
-            "iss": base_url,
+            "iss": issuer,
             "sub": user_id,
             "aud": client_id,
             "iat": now,
@@ -896,9 +901,10 @@ class OIDCUserInfoView(HomeAssistantView):
                 format=serialization.PublicFormat.SubjectPublicKeyInfo,
             )
 
-            # Decode and verify the JWT with issuer verification
-            # Get expected issuer from request base URL
-            expected_issuer = get_issuer_from_request(request)
+            # Decode and verify the JWT with issuer verification. The /oidc
+            # suffix matches what the token endpoint signs into the iss claim
+            # (RFC 8414).
+            expected_issuer = f"{get_issuer_from_request(request)}/oidc"
 
             payload = jwt.decode(
                 access_token,

--- a/custom_components/oidc_provider/manifest.json
+++ b/custom_components/oidc_provider/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-oidc-server/issues",
   "requirements": ["PyJWT>=2.8.0", "cryptography>=43.0.0"],
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/custom_components/oidc_provider/token_validator.py
+++ b/custom_components/oidc_provider/token_validator.py
@@ -92,6 +92,13 @@ def validate_access_token(
             format=serialization.PublicFormat.SubjectPublicKeyInfo,
         )
 
+        # The issuer signed into tokens always has the /oidc suffix (RFC 8414).
+        # External callers (e.g. hass-mcp-server) typically pass the base URL
+        # without the suffix; tolerate both forms so they don't have to change
+        # in lockstep.
+        if not expected_issuer.rstrip("/").endswith("/oidc"):
+            expected_issuer = expected_issuer.rstrip("/") + "/oidc"
+
         # Verify and decode the token with issuer verification
         payload = jwt.decode(
             token,

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -17,10 +17,11 @@ def load_const_module():
 def test_discovery_document_structure():
     """Test OIDC discovery document has required fields."""
     base_url = "https://example.com"
+    issuer = f"{base_url}/oidc"
     const = load_const_module()
 
     discovery = {
-        "issuer": base_url,
+        "issuer": issuer,
         "authorization_endpoint": f"{base_url}/auth/oidc/authorize",
         "token_endpoint": f"{base_url}/auth/oidc/token",
         "userinfo_endpoint": f"{base_url}/auth/oidc/userinfo",
@@ -59,7 +60,7 @@ def test_discovery_document_structure():
     assert "id_token_signing_alg_values_supported" in discovery
 
     # Validate values
-    assert discovery["issuer"] == base_url
+    assert discovery["issuer"] == issuer
     assert "code" in discovery["response_types_supported"]
     assert "RS256" in discovery["id_token_signing_alg_values_supported"]
     assert "openid" in discovery["scopes_supported"]

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -196,8 +196,9 @@ async def test_oidc_discovery_endpoint():
     body = response.body.decode("utf-8")
     data = json.loads(body)
 
-    # Verify required OIDC fields
-    assert data["issuer"] == "https://homeassistant.local"
+    # Verify required OIDC fields. The issuer carries the /oidc suffix per
+    # RFC 8414 so it resolves to /oidc/.well-known/openid-configuration.
+    assert data["issuer"] == "https://homeassistant.local/oidc"
     assert data["authorization_endpoint"] == "https://homeassistant.local/oidc/authorize"
     assert data["token_endpoint"] == "https://homeassistant.local/oidc/token"
     assert data["userinfo_endpoint"] == "https://homeassistant.local/oidc/userinfo"
@@ -236,7 +237,7 @@ async def test_oidc_discovery_with_proxy():
     data = json.loads(body)
 
     # Verify URLs use the proxy host
-    assert data["issuer"] == "https://ha.example.com"
+    assert data["issuer"] == "https://ha.example.com/oidc"
     assert data["authorization_endpoint"] == "https://ha.example.com/oidc/authorize"
     assert data["token_endpoint"] == "https://ha.example.com/oidc/token"
 
@@ -256,7 +257,7 @@ async def test_oauth2_authorization_server_metadata():
     data = json.loads(body)
 
     # Verify required fields
-    assert data["issuer"] == "https://homeassistant.local"
+    assert data["issuer"] == "https://homeassistant.local/oidc"
     assert data["authorization_endpoint"] == "https://homeassistant.local/oidc/authorize"
     assert data["token_endpoint"] == "https://homeassistant.local/oidc/token"
     assert data["registration_endpoint"] == "https://homeassistant.local/oidc/register"
@@ -281,7 +282,7 @@ async def test_oauth2_authorization_server_metadata_alternate_path():
     data = json.loads(body)
 
     # Should return the same metadata as the primary endpoint
-    assert data["issuer"] == "https://homeassistant.local"
+    assert data["issuer"] == "https://homeassistant.local/oidc"
     assert data["authorization_endpoint"] == "https://homeassistant.local/oidc/authorize"
     assert data["token_endpoint"] == "https://homeassistant.local/oidc/token"
     assert data["registration_endpoint"] == "https://homeassistant.local/oidc/register"
@@ -1708,7 +1709,7 @@ async def test_oidc_userinfo_endpoint():
         "sub": "user123",
         "iat": int(time.time()),
         "exp": int(time.time()) + 3600,
-        "iss": "http://localhost",
+        "iss": "http://localhost/oidc",
         "aud": "test_client",
         "scope": "openid profile email",
     }
@@ -1785,7 +1786,7 @@ async def test_oidc_userinfo_includes_groups_when_scope_requested():
         "sub": "user123",
         "iat": int(time.time()),
         "exp": int(time.time()) + 3600,
-        "iss": "http://localhost",
+        "iss": "http://localhost/oidc",
         "aud": "test_client",
         "scope": "openid profile groups",
     }
@@ -1854,7 +1855,7 @@ async def test_oidc_userinfo_groups_for_owner():
         "sub": "owner123",
         "iat": int(time.time()),
         "exp": int(time.time()) + 3600,
-        "iss": "http://localhost",
+        "iss": "http://localhost/oidc",
         "aud": "test_client",
         "scope": "openid groups",
     }
@@ -1923,7 +1924,7 @@ async def test_oidc_userinfo_groups_for_regular_user():
         "sub": "regular123",
         "iat": int(time.time()),
         "exp": int(time.time()) + 3600,
-        "iss": "http://localhost",
+        "iss": "http://localhost/oidc",
         "aud": "test_client",
         "scope": "openid groups",
     }
@@ -1991,7 +1992,7 @@ async def test_oidc_userinfo_groups_for_read_only_user():
         "sub": "readonly123",
         "iat": int(time.time()),
         "exp": int(time.time()) + 3600,
-        "iss": "http://localhost",
+        "iss": "http://localhost/oidc",
         "aud": "test_client",
         "scope": "openid groups",
     }
@@ -2059,7 +2060,7 @@ async def test_oidc_userinfo_only_returns_sub_without_scopes():
         "sub": "user123",
         "iat": int(time.time()),
         "exp": int(time.time()) + 3600,
-        "iss": "http://localhost",
+        "iss": "http://localhost/oidc",
         "aud": "test_client",
         "scope": "openid",
     }
@@ -2130,7 +2131,7 @@ async def test_oidc_userinfo_returns_email_when_username_is_email():
         "sub": "user123",
         "iat": int(time.time()),
         "exp": int(time.time()) + 3600,
-        "iss": "http://localhost",
+        "iss": "http://localhost/oidc",
         "aud": "test_client",
         "scope": "openid email",
     }

--- a/tests/test_id_token.py
+++ b/tests/test_id_token.py
@@ -260,10 +260,12 @@ async def test_id_token_issued_with_required_claims():
 
     claims = _decode_id_token(body["id_token"], public_pem)
 
-    # Required claims (OIDC Core §2)
+    # Required claims (OIDC Core §2). The /oidc suffix on iss is required by
+    # RFC 8414 so it matches authorization_servers entries advertised by
+    # paired protected-resource servers (e.g. hass-mcp-server).
     assert claims["sub"] == "user123"
     assert claims["aud"] == "test_client"
-    assert claims["iss"]
+    assert claims["iss"] == f"{_FIXED_ISSUER}/oidc"
     assert claims["iat"] <= int(time.time())
     assert claims["exp"] > claims["iat"]
 

--- a/tests/test_token_validator.py
+++ b/tests/test_token_validator.py
@@ -42,7 +42,7 @@ def test_validate_access_token_valid(mock_hass_with_keys):
         "sub": "test_user",
         "iat": int(time.time()),
         "exp": int(time.time()) + 3600,
-        "iss": "http://localhost",
+        "iss": "http://localhost/oidc",
         "aud": "test_client",  # Required audience
     }
 
@@ -60,7 +60,7 @@ def test_validate_access_token_valid(mock_hass_with_keys):
 
     assert result is not None
     assert result["sub"] == "test_user"
-    assert result["iss"] == "http://localhost"
+    assert result["iss"] == "http://localhost/oidc"
 
 
 def test_validate_access_token_expired(mock_hass_with_keys):
@@ -72,7 +72,7 @@ def test_validate_access_token_expired(mock_hass_with_keys):
         "sub": "test_user",
         "iat": int(time.time()) - 7200,
         "exp": int(time.time()) - 3600,  # Expired 1 hour ago
-        "iss": "http://localhost",
+        "iss": "http://localhost/oidc",
     }
 
     private_key_pem = private_key.private_bytes(
@@ -102,7 +102,7 @@ def test_validate_access_token_invalid_signature(mock_hass_with_keys):
         "sub": "test_user",
         "iat": int(time.time()),
         "exp": int(time.time()) + 3600,
-        "iss": "http://localhost",
+        "iss": "http://localhost/oidc",
     }
 
     different_key_pem = different_key.private_bytes(
@@ -160,7 +160,7 @@ def test_validate_access_token_with_custom_claims(mock_hass_with_keys):
         "email": "test@example.com",
         "iat": int(time.time()),
         "exp": int(time.time()) + 3600,
-        "iss": "http://localhost",
+        "iss": "http://localhost/oidc",
         "aud": "test_client",  # Required audience
         "custom_claim": "custom_value",
     }
@@ -253,7 +253,7 @@ async def test_validate_access_token_accepts_valid_audience(mock_hass_with_keys)
         "sub": "user123",
         "iat": int(time.time()),
         "exp": int(time.time()) + 3600,
-        "iss": "http://localhost",
+        "iss": "http://localhost/oidc",
         "aud": "test_client",  # Registered client
     }
     token = jwt.encode(payload, private_pem, algorithm="RS256")
@@ -316,3 +316,61 @@ async def test_validate_access_token_rejects_invalid_issuer(mock_hass_with_keys)
 
     result = validate_access_token(hass, token, "http://localhost")
     assert result is None
+
+
+async def test_validate_access_token_accepts_issuer_without_oidc_suffix(mock_hass_with_keys):
+    """Callers may pass the base URL with or without the /oidc suffix.
+
+    Tokens carry iss=base_url/oidc (RFC 8414). Sibling integrations like
+    hass-mcp-server pass the unsuffixed base URL; validate_access_token
+    normalizes it before checking.
+    """
+    hass, private_key = mock_hass_with_keys
+    hass.data[DOMAIN]["clients"] = {"test_client": {}}
+
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    payload = {
+        "sub": "user123",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 3600,
+        "iss": "https://ha.example.com/oidc",
+        "aud": "test_client",
+    }
+    token = jwt.encode(payload, private_pem, algorithm="RS256")
+
+    # Caller passes the base URL (no /oidc suffix). Validation still succeeds.
+    result = validate_access_token(hass, token, "https://ha.example.com")
+    assert result is not None
+    assert result["sub"] == "user123"
+
+    # And the canonical /oidc-suffixed form works identically.
+    result = validate_access_token(hass, token, "https://ha.example.com/oidc")
+    assert result is not None
+    assert result["sub"] == "user123"
+
+
+async def test_validate_access_token_rejects_unsuffixed_iss(mock_hass_with_keys):
+    """Tokens whose iss lacks the /oidc suffix are rejected."""
+    hass, private_key = mock_hass_with_keys
+    hass.data[DOMAIN]["clients"] = {"test_client": {}}
+
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    payload = {
+        "sub": "user123",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 3600,
+        "iss": "https://ha.example.com",  # missing /oidc suffix
+        "aud": "test_client",
+    }
+    token = jwt.encode(payload, private_pem, algorithm="RS256")
+
+    assert validate_access_token(hass, token, "https://ha.example.com") is None
+    assert validate_access_token(hass, token, "https://ha.example.com/oidc") is None


### PR DESCRIPTION
Fixes #23.

Strict OAuth clients (Anthropic Claude Cowork, and others reported against Slack/GitHub MCP servers) reject tokens from this provider because the JWT `iss` claim and the discovery document's `issuer` field omit the `/oidc` path segment. Per RFC 8414 §2, the issuer URL must resolve to its own metadata when concatenated with `/.well-known/oauth-authorization-server`. The metadata lives under `/oidc/.well-known/openid-configuration`, so the issuer must be `https://your-ha/oidc`, not `https://your-ha`.

Three coordinated changes in `custom_components/oidc_provider/`:

- `http.py`: all three discovery views (OIDC discovery, RFC 8414 metadata, and the alternate-path RFC 8414 view) publish `issuer: {base_url}/oidc`. The access-token and id-token generators sign `iss` with the same suffixed value. The userinfo endpoint expects the suffixed issuer when verifying.
- `token_validator.py`: `validate_access_token` normalizes `expected_issuer` by appending `/oidc` when it's missing, so the paired `hass-mcp-server` (which passes the bare base URL) keeps working without a coordinated release.
- `manifest.json`: bumped to 1.4.1.

Tests updated to reflect the suffixed `iss`, plus two new cases in `tests/test_token_validator.py` covering the tolerance shim (accepts both forms) and confirming that legacy unsuffixed `iss` values are rejected.

After this change the JWT `iss` and discovery `issuer` both equal `https://your-ha/oidc`, matching the `authorization_servers` entry advertised by `hass-mcp-server`.
