### PR TITLE
fix: surface JWT header alg/kid on token validation failure

### DIFF
--- a/custom_components/oidc_provider/manifest.json
+++ b/custom_components/oidc_provider/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-oidc-server/issues",
   "requirements": ["PyJWT>=2.8.0", "cryptography>=43.0.0"],
-  "version": "1.4.1"
+  "version": "1.4.2"
 }

--- a/custom_components/oidc_provider/token_validator.py
+++ b/custom_components/oidc_provider/token_validator.py
@@ -12,6 +12,29 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "oidc_provider"
 
 
+def _describe_token(token: str) -> str:
+    """Return safe-to-log metadata about a bearer token.
+
+    Logs structural shape (length, segment count) and the unverified JWS header
+    fields (alg, kid, typ). The signing key is not used and the payload is never
+    decoded, so this is safe to call on tokens that fail validation. The token
+    string itself is never logged.
+    """
+    if not token:
+        return "token=<empty>"
+    parts: list[str] = [f"length={len(token)}", f"segments={token.count('.') + 1}"]
+    try:
+        header = jwt.get_unverified_header(token)
+    except Exception:
+        parts.append("header=<unparseable>")
+        return " ".join(parts)
+    for key in ("alg", "kid", "typ"):
+        value = header.get(key)
+        if value is not None:
+            parts.append(f"{key}={value!r}")
+    return " ".join(parts)
+
+
 def get_issuer_from_request(request: web.Request) -> str:
     """
     Get the expected issuer URL from a request.
@@ -124,11 +147,11 @@ def validate_access_token(
 
         return payload
     except jwt.ExpiredSignatureError:
-        _LOGGER.warning("Token expired")
+        _LOGGER.warning("Token expired (%s)", _describe_token(token))
         return None
     except jwt.InvalidTokenError as e:
-        _LOGGER.warning("Invalid token: %s", e)
+        _LOGGER.warning("Invalid token: %s (%s)", e, _describe_token(token))
         return None
     except Exception as e:
-        _LOGGER.error("Error validating token: %s", e)
+        _LOGGER.error("Error validating token: %s (%s)", e, _describe_token(token))
         return None

--- a/tests/test_token_validator.py
+++ b/tests/test_token_validator.py
@@ -1,5 +1,6 @@
 """Tests for token validator."""
 
+import logging
 import time
 
 import jwt
@@ -9,7 +10,10 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 from custom_components.oidc_provider.const import DOMAIN
-from custom_components.oidc_provider.token_validator import validate_access_token
+from custom_components.oidc_provider.token_validator import (
+    _describe_token,
+    validate_access_token,
+)
 
 
 @pytest.fixture
@@ -374,3 +378,82 @@ async def test_validate_access_token_rejects_unsuffixed_iss(mock_hass_with_keys)
 
     assert validate_access_token(hass, token, "https://ha.example.com") is None
     assert validate_access_token(hass, token, "https://ha.example.com/oidc") is None
+
+
+def test_describe_token_extracts_header_fields():
+    """JWT-shaped tokens surface alg/kid/typ for diagnostics."""
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    token = jwt.encode(
+        {"sub": "u"}, private_pem, algorithm="RS256", headers={"kid": "abc", "typ": "JWT"}
+    )
+
+    info = _describe_token(token)
+
+    assert "alg='RS256'" in info
+    assert "kid='abc'" in info
+    assert "typ='JWT'" in info
+    assert "segments=3" in info
+    assert "length=" in info
+    assert token not in info
+
+
+def test_describe_token_marks_unparseable_input():
+    """Non-JWT bearer tokens are logged as <unparseable> without leaking content."""
+    info = _describe_token("not-a-jwt")
+
+    assert "header=<unparseable>" in info
+    assert "length=9" in info
+    assert "segments=1" in info
+    assert "not-a-jwt" not in info
+
+
+def test_describe_token_handles_empty():
+    """Empty tokens don't blow up the diagnostic helper."""
+    assert _describe_token("") == "token=<empty>"
+
+
+def test_invalid_alg_failure_logs_actual_alg(mock_hass_with_keys, caplog):
+    """An HS256 token presented for RS256 validation logs its alg header."""
+    hass, _ = mock_hass_with_keys
+    hass.data[DOMAIN]["clients"] = {"test_client": {}}
+
+    # Sign with HS256 so PyJWT raises InvalidAlgorithmError before signature checks.
+    token = jwt.encode(
+        {
+            "sub": "u",
+            "iss": "http://localhost/oidc",
+            "aud": "test_client",
+            "iat": int(time.time()),
+            "exp": int(time.time()) + 3600,
+        },
+        "shared-secret",
+        algorithm="HS256",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.oidc_provider.token_validator"):
+        result = validate_access_token(hass, token, "http://localhost")
+
+    assert result is None
+    assert any(
+        "alg='HS256'" in record.getMessage() and "Invalid token" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_malformed_token_failure_logs_unparseable(mock_hass_with_keys, caplog):
+    """A non-JWT bearer surfaces as unparseable in the warning."""
+    hass, _ = mock_hass_with_keys
+    hass.data[DOMAIN]["clients"] = {"test_client": {}}
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.oidc_provider.token_validator"):
+        result = validate_access_token(hass, "definitely-not-a-jwt", "http://localhost")
+
+    assert result is None
+    assert any("header=<unparseable>" in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
Diagnostic-only change for ganhammar/hass-mcp-server#47.

A user reported Claude.ai token validation failing with `Invalid token: The specified alg value is not allowed`. The OIDC provider only allows RS256 and only signs with RS256, so the report indicates a token with a non-RS256 header is reaching the validator, but the current warning doesn't tell us what `alg` was actually presented, which makes the issue impossible to triage from logs alone.

This change augments the `InvalidTokenError` / `ExpiredSignatureError` / catch-all warning lines with a structured "describe" string that includes the unverified header's `alg`, `kid`, `typ`, plus the token's length and segment count. `jwt.get_unverified_header` does not verify the signature, so this is safe to call on tokens that fail validation. The token contents are never logged.

Version bumped 1.4.1 → 1.4.2.
