### PR TITLE
Bind access token aud to RFC 8707 resource and honor request host

### DIFF
--- a/custom_components/oidc_provider/http.py
+++ b/custom_components/oidc_provider/http.py
@@ -8,6 +8,7 @@ import secrets
 import time
 import uuid
 from typing import Any
+from urllib.parse import urlparse
 
 import jwt
 from aiohttp import web
@@ -51,6 +52,21 @@ from .security import verify_client_secret
 from .token_validator import get_issuer_from_request
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _normalize_resource(resource: str | None) -> str | None:
+    """Validate an RFC 8707 resource indicator and return it, or None.
+
+    The resource must be an absolute URI without a fragment (RFC 8707 §2).
+    Malformed values are dropped so they can never end up as a token audience.
+    """
+    if not resource:
+        return None
+    parsed = urlparse(resource)
+    if not parsed.scheme or not parsed.netloc or parsed.fragment:
+        _LOGGER.warning("Ignoring malformed resource indicator: %s", resource)
+        return None
+    return resource
 
 
 async def _save_refresh_tokens(hass: HomeAssistant) -> None:
@@ -190,6 +206,7 @@ class OIDCContinueView(HomeAssistantView):
         nonce = stored_request.get("nonce")
         code_challenge = stored_request.get("code_challenge")
         code_challenge_method = stored_request.get("code_challenge_method")
+        resource = stored_request.get("resource")
 
         # Clean up
         del pending_requests[request_id]
@@ -212,6 +229,7 @@ class OIDCContinueView(HomeAssistantView):
             "auth_time": int(time.time()),
             "code_challenge": code_challenge,
             "code_challenge_method": code_challenge_method,
+            "resource": resource,
             "expires_at": time.time() + AUTHORIZATION_CODE_EXPIRY,
         }
 
@@ -359,6 +377,9 @@ class OIDCAuthorizationView(HomeAssistantView):
         code_challenge_method = request.query.get(
             "code_challenge_method", CODE_CHALLENGE_METHOD_S256
         )
+        # RFC 8707 resource indicator. Identifies the protected resource (e.g. the
+        # MCP server) the access token will be used at; bound into the token aud.
+        resource = _normalize_resource(request.query.get("resource"))
 
         # Validate parameters
         if not client_id or not redirect_uri or response_type != RESPONSE_TYPE_CODE:
@@ -433,6 +454,7 @@ class OIDCAuthorizationView(HomeAssistantView):
             "nonce": nonce,
             "code_challenge": code_challenge,
             "code_challenge_method": code_challenge_method,
+            "resource": resource,
             "expires_at": time.time() + 600,  # 10 minutes
         }
 
@@ -660,17 +682,26 @@ class OIDCTokenView(HomeAssistantView):
         nonce = auth_data.get("nonce")
         auth_time = auth_data.get("auth_time")
 
-        access_token = await self._generate_access_token(_request, hass, user_id, scope, client_id)
+        # The token audience is bound to the resource requested at the authorize
+        # step (RFC 8707). A token request MAY also carry a resource indicator;
+        # honor it only when the authorize step didn't specify one.
+        resource = auth_data.get("resource") or _normalize_resource(data.get("resource"))
+
+        access_token = await self._generate_access_token(
+            _request, hass, user_id, scope, client_id, audience=resource
+        )
         refresh_token = secrets.token_urlsafe(32)
 
         # Store refresh token (nonce + auth_time persisted so future refreshes
-        # produce spec-correct id_tokens after Home Assistant restarts).
+        # produce spec-correct id_tokens after Home Assistant restarts; resource
+        # persisted so refreshed access tokens keep the same audience binding).
         hass.data[DOMAIN]["refresh_tokens"][refresh_token] = {
             "user_id": user_id,
             "client_id": client_id,
             "scope": scope,
             "nonce": nonce,
             "auth_time": auth_time,
+            "resource": resource,
             "expires_at": time.time() + REFRESH_TOKEN_EXPIRY,
         }
 
@@ -727,9 +758,15 @@ class OIDCTokenView(HomeAssistantView):
         if token_data["client_id"] != data.get("client_id"):
             return web.json_response({"error": "invalid_grant"}, status=400)
 
-        # Generate new access token
+        # Generate new access token, preserving the original resource binding
+        # (RFC 8707) so refreshed tokens stay valid at the same resource.
         access_token = await self._generate_access_token(
-            _request, hass, token_data["user_id"], token_data["scope"], token_data["client_id"]
+            _request,
+            hass,
+            token_data["user_id"],
+            token_data["scope"],
+            token_data["client_id"],
+            audience=token_data.get("resource"),
         )
 
         # Re-issue an id_token when openid scope is granted (OIDC Core §12.2).
@@ -759,7 +796,13 @@ class OIDCTokenView(HomeAssistantView):
         return web.json_response(response_body)
 
     async def _generate_access_token(
-        self, request: web.Request, hass: HomeAssistant, user_id: str, scope: str, client_id: str
+        self,
+        request: web.Request,
+        hass: HomeAssistant,
+        user_id: str,
+        scope: str,
+        client_id: str,
+        audience: str | None = None,
     ) -> str:
         """Generate JWT access token."""
         now = int(time.time())
@@ -771,15 +814,20 @@ class OIDCTokenView(HomeAssistantView):
         base_url = get_issuer_from_request(request)
         issuer = f"{base_url}/oidc"
 
+        # When a resource indicator was supplied (RFC 8707), bind aud to that
+        # resource and record the client in azp. Otherwise fall back to the
+        # client_id as the audience for backward compatibility.
         payload = {
             "sub": user_id,
             "iat": now,
             "exp": now + ACCESS_TOKEN_EXPIRY,
             "iss": issuer,
-            "aud": client_id,
+            "aud": audience or client_id,
             "scope": scope,
             "token_use": TOKEN_USE_ACCESS,
         }
+        if audience:
+            payload["azp"] = client_id
 
         # Include groups claim when the groups scope is requested
         requested_scopes = scope.split() if scope else []
@@ -926,15 +974,13 @@ class OIDCUserInfoView(HomeAssistantView):
                 _LOGGER.warning("ID token presented at userinfo endpoint")
                 return web.json_response({"error": "invalid_token"}, status=401)
 
-            # Verify the audience claim exists and matches a registered client
+            # Verify the audience claim exists. Access tokens are audience-bound
+            # either to a registered client_id (legacy) or to a protected
+            # resource URI (RFC 8707). Both are minted and signed by this
+            # provider, which the decode above already verified, so either form
+            # is accepted for returning the user's own profile.
             aud = payload.get("aud")
             if not aud:
-                return web.json_response({"error": "invalid_token"}, status=401)
-
-            clients = hass.data[DOMAIN].get("clients", {})
-            if aud not in clients:
-                # Token audience doesn't match any registered client (confused deputy attack)
-                _LOGGER.warning("Token with invalid audience: %s", aud)
                 return web.json_response({"error": "invalid_token"}, status=401)
 
             # Extract user info from JWT

--- a/custom_components/oidc_provider/manifest.json
+++ b/custom_components/oidc_provider/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-oidc-server/issues",
   "requirements": ["PyJWT>=2.8.0", "cryptography>=43.0.0"],
-  "version": "1.4.2"
+  "version": "1.5.0"
 }

--- a/custom_components/oidc_provider/token_validator.py
+++ b/custom_components/oidc_provider/token_validator.py
@@ -49,23 +49,24 @@ def get_issuer_from_request(request: web.Request) -> str:
     Returns:
         The base URL for this server
     """
-    # Check for X-Forwarded headers (proxy setup)
-    forwarded_proto = request.headers.get("X-Forwarded-Proto")
-    forwarded_host = request.headers.get("X-Forwarded-Host")
+    # Derive the host the client actually used. X-Forwarded-Host is preferred,
+    # but some proxies (e.g. Cloudflare Tunnel) forward the original Host header
+    # and X-Forwarded-Proto without setting X-Forwarded-Host, so fall back to the
+    # Host header. The protocol comes from X-Forwarded-Proto when the proxy
+    # terminates TLS, otherwise from the request scheme.
+    host = request.headers.get("X-Forwarded-Host") or request.headers.get("Host")
+    proto = request.headers.get("X-Forwarded-Proto") or request.url.scheme
 
-    if forwarded_proto and forwarded_host:
-        # Use forwarded headers from proxy
-        base_url = f"{forwarded_proto}://{forwarded_host}"
-    else:
-        # Try Home Assistant's configured external URL
-        external_url = _get_ha_external_url(request)
-        if external_url:
-            base_url = external_url.rstrip("/")
-        else:
-            # Direct connection, use request URL
-            base_url = str(request.url.origin())
+    if host:
+        return f"{proto}://{host}"
 
-    return base_url
+    # No usable host header: fall back to HA's configured external URL, then the
+    # raw request origin.
+    external_url = _get_ha_external_url(request)
+    if external_url:
+        return external_url.rstrip("/")
+
+    return str(request.url.origin())
 
 
 def _get_ha_external_url(request: web.Request) -> str | None:
@@ -86,7 +87,10 @@ def _get_ha_external_url(request: web.Request) -> str | None:
 
 
 def validate_access_token(
-    hass: HomeAssistant, token: str, expected_issuer: str
+    hass: HomeAssistant,
+    token: str,
+    expected_issuer: str,
+    expected_audience: str | None = None,
 ) -> dict[str, Any] | None:
     """
     Validate an OAuth access token issued by this OIDC provider.
@@ -95,6 +99,11 @@ def validate_access_token(
         hass: Home Assistant instance
         token: The access token to validate
         expected_issuer: Expected issuer URL
+        expected_audience: The resource this token must be bound to (RFC 8707).
+            When provided, the token is accepted if its aud contains this value.
+            Tokens whose aud is a registered client_id are also accepted, so
+            tokens issued before resource binding (or by clients that don't send
+            a resource indicator) keep working.
 
     Returns:
         Token payload if valid, None otherwise
@@ -133,19 +142,25 @@ def validate_access_token(
             },
         )
 
-        # Verify the audience claim exists and matches a registered client
+        # Verify the audience claim exists.
         aud = payload.get("aud")
         if not aud:
             _LOGGER.warning("Token missing audience claim")
             return None
 
-        clients = hass.data[DOMAIN].get("clients", {})
-        if aud not in clients:
-            # Token audience doesn't match any registered client
-            _LOGGER.warning("Token with invalid audience: %s", aud)
-            return None
+        audiences = aud if isinstance(aud, list) else [aud]
 
-        return payload
+        # Accept the token when its audience is bound to the expected resource
+        # (RFC 8707) or, for backward compatibility, to a registered client_id.
+        if expected_audience is not None and expected_audience in audiences:
+            return payload
+
+        clients = hass.data[DOMAIN].get("clients", {})
+        if any(audience in clients for audience in audiences):
+            return payload
+
+        _LOGGER.warning("Token with invalid audience: %s", aud)
+        return None
     except jwt.ExpiredSignatureError:
         _LOGGER.warning("Token expired (%s)", _describe_token(token))
         return None

--- a/test_oidc_flow.py
+++ b/test_oidc_flow.py
@@ -2,6 +2,7 @@
 
 import base64
 import hashlib
+import json
 import secrets
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -11,11 +12,20 @@ from urllib.parse import parse_qs, urlparse
 import requests
 
 # Configuration
-HA_URL = input("Enter your Home Assistant URL (e.g., https://homeassistant.local): ").strip()
+BASE_URL = (
+    input("Enter your Home Assistant base URL (e.g., https://homeassistant.local): ")
+    .strip()
+    .rstrip("/")
+)
 CLIENT_ID = input("Enter your client_id: ").strip()
 CLIENT_SECRET = input("Enter your client_secret: ").strip()
 CALLBACK_PORT = int(input("Enter callback port (default 3555): ").strip() or "3555")
 REDIRECT_URI = f"http://localhost:{CALLBACK_PORT}/callback"
+
+# RFC 8707 resource indicator. This is the canonical URI of the MCP server that
+# Claude sends in the authorize and token requests, and that the issued token's
+# aud claim must be bound to. Defaults to {base}/api/mcp.
+RESOURCE = input(f"Enter resource (default {BASE_URL}/api/mcp): ").strip() or f"{BASE_URL}/api/mcp"
 
 # Ask if user wants to test with PKCE
 use_pkce = input("Test with PKCE? (y/n, default: y): ").strip().lower()
@@ -78,15 +88,24 @@ class CallbackHandler(BaseHTTPRequestHandler):
 
 
 print("\n=== Testing OIDC Discovery ===")
-discovery_url = f"{HA_URL}/.well-known/openid-configuration"
+discovery_url = f"{BASE_URL}/oidc/.well-known/openid-configuration"
 response = requests.get(discovery_url)
 print(f"Status: {response.status_code}")
 if response.ok:
     discovery = response.json()
-    print(f"Issuer: {discovery['issuer']}")
-    print(f"Authorization Endpoint: {discovery['authorization_endpoint']}")
-    print(f"Token Endpoint: {discovery['token_endpoint']}")
-    print(f"UserInfo Endpoint: {discovery.get('userinfo_endpoint')}")
+    print(f"Advertised issuer: {discovery['issuer']}")
+    print(f"Advertised authorization endpoint: {discovery['authorization_endpoint']}")
+
+    # The server builds its advertised endpoints from get_issuer_from_request,
+    # which falls back to HA's external URL when the request host can't be
+    # determined (e.g. behind a tunnel that doesn't forward the host). To keep
+    # this test on the host you typed, drive the endpoints off BASE_URL instead
+    # of trusting the advertised values.
+    discovery["authorization_endpoint"] = f"{BASE_URL}/oidc/authorize"
+    discovery["token_endpoint"] = f"{BASE_URL}/oidc/token"
+    discovery["userinfo_endpoint"] = f"{BASE_URL}/oidc/userinfo"
+    print(f"Using authorization endpoint: {discovery['authorization_endpoint']}")
+    print(f"Using token endpoint: {discovery['token_endpoint']}")
     if "code_challenge_methods_supported" in discovery:
         print(f"PKCE Methods: {discovery['code_challenge_methods_supported']}")
 else:
@@ -125,6 +144,7 @@ auth_params = {
     "response_type": "code",
     "scope": "openid profile",
     "state": "test123",
+    "resource": RESOURCE,
 }
 
 if USE_PKCE:
@@ -178,6 +198,7 @@ token_data = {
     "client_id": CLIENT_ID,
     "client_secret": CLIENT_SECRET,
     "redirect_uri": REDIRECT_URI,
+    "resource": RESOURCE,
 }
 
 if USE_PKCE:
@@ -196,6 +217,34 @@ if token_response.ok:
         print(f"✓ Refresh Token: {tokens['refresh_token'][:50]}...")
 
     access_token = tokens["access_token"]
+
+    # Decode the access token payload (without signature verification) to inspect
+    # the audience binding. Per RFC 8707 / the MCP authorization spec, aud must
+    # be bound to the requested resource. If aud comes back as the client_id
+    # instead of RESOURCE, the server ignored the resource indicator, which is
+    # why Claude rejects the connection with McpAuthorizationError.
+    print("\n=== Access Token Claims (unverified decode) ===")
+    try:
+        payload_segment = access_token.split(".")[1]
+        payload_segment += "=" * (-len(payload_segment) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload_segment))
+        for key in ("iss", "aud", "sub", "scope", "token_use", "exp"):
+            if key in claims:
+                print(f"  {key}: {claims[key]}")
+
+        print(f"\nRequested resource: {RESOURCE}")
+        token_aud = claims.get("aud")
+        if token_aud == RESOURCE:
+            print("✓ aud is bound to the requested resource (RFC 8707 compliant)")
+        else:
+            print(
+                f"✗ aud is NOT the requested resource (got {token_aud!r}, "
+                f"expected {RESOURCE!r}).\n"
+                "  The server ignored the resource indicator. This is why Claude "
+                "rejects the token (McpAuthorizationError)."
+            )
+    except Exception as e:
+        print(f"  Could not decode access token: {e}")
 else:
     print(f"Error: {token_response.text}")
     exit(1)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -69,20 +69,36 @@ def test_get_base_url_with_partial_forwarded_headers():
     request.url.origin.assert_called_once()
 
 
-def test_get_base_url_with_only_host_header():
-    """Test get_issuer_from_request with only X-Forwarded-Host (should use fallback)."""
-    # Create a mock request with only X-Forwarded-Host
+def test_get_base_url_with_only_forwarded_host():
+    """X-Forwarded-Host without X-Forwarded-Proto uses the request scheme."""
     request = Mock()
     request.headers = {
         "X-Forwarded-Host": "example.com",
     }
+    request.url.scheme = "https"
     request.url.origin.return_value = "http://localhost:8123"
 
     result = get_issuer_from_request(request)
 
-    assert result == "http://localhost:8123"
-    # Should fall back to origin() when both headers aren't present
-    request.url.origin.assert_called_once()
+    assert result == "https://example.com"
+    request.url.origin.assert_not_called()
+
+
+def test_get_base_url_with_host_header_and_forwarded_proto():
+    """A proxy that forwards the Host header and X-Forwarded-Proto (e.g. a
+    Cloudflare Tunnel) but omits X-Forwarded-Host still yields the client host."""
+    request = Mock()
+    request.headers = {
+        "X-Forwarded-Proto": "https",
+        "Host": "hem.example.com",
+    }
+    request.url.scheme = "http"
+    request.url.origin.return_value = "http://localhost:8123"
+
+    result = get_issuer_from_request(request)
+
+    assert result == "https://hem.example.com"
+    request.url.origin.assert_not_called()
 
 
 def test_get_base_url_uses_ha_external_url():
@@ -905,6 +921,77 @@ async def test_oidc_token_view_basic_auth():
     mock_token_store.async_save.assert_called_once()
     saved_data = mock_token_store.async_save.call_args[0][0]
     assert "refresh_tokens" in saved_data
+
+
+@pytest.mark.asyncio
+async def test_oidc_token_view_binds_aud_to_resource():
+    """Access token aud is bound to the requested resource (RFC 8707)."""
+    import base64
+
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    from custom_components.oidc_provider.security import hash_client_secret
+
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+
+    mock_token_store = Mock()
+    mock_token_store.async_save = AsyncMock()
+
+    resource = "https://ha.example.com/api/mcp"
+    hass = Mock()
+    hass.data = {
+        DOMAIN: {
+            "clients": {"test_client": {"client_secret_hash": hash_client_secret("test_secret")}},
+            "authorization_codes": {
+                "valid_code": {
+                    "client_id": "test_client",
+                    "redirect_uri": "https://example.com/callback",
+                    "user_id": "user123",
+                    "scope": "openid",
+                    "resource": resource,
+                    "expires_at": time.time() + 600,
+                }
+            },
+            "refresh_tokens": {},
+            "rate_limit_attempts": {},
+            "jwt_private_key": private_key,
+            "jwt_kid": "test-kid-1",
+            "token_store": mock_token_store,
+        }
+    }
+
+    credentials = base64.b64encode(b"test_client:test_secret").decode("utf-8")
+    request = MagicMock()
+    request.app = {"hass": hass}
+    request.remote = "127.0.0.1"
+    request.headers = {"Authorization": f"Basic {credentials}"}
+    request.post = AsyncMock(
+        return_value={
+            "grant_type": "authorization_code",
+            "code": "valid_code",
+            "redirect_uri": "https://example.com/callback",
+        }
+    )
+
+    from custom_components.oidc_provider.http import OIDCTokenView
+
+    view = OIDCTokenView()
+    response = await view.post(request)
+    assert response.status == 200
+    data = json.loads(response.body.decode("utf-8"))
+
+    claims = jwt.decode(data["access_token"], options={"verify_signature": False})
+    assert claims["aud"] == resource
+    assert claims["azp"] == "test_client"
+
+    # The resource is persisted on the refresh token so refreshed access tokens
+    # keep the same audience binding.
+    saved = mock_token_store.async_save.call_args[0][0]["refresh_tokens"]
+    assert saved
+    assert all(rt["resource"] == resource for rt in saved.values())
 
 
 @pytest.mark.asyncio
@@ -1766,6 +1853,69 @@ async def test_oidc_userinfo_endpoint():
     assert data["name"] == "Test User"
     assert "email" not in data  # "Test User" doesn't look like an email
     assert "groups" not in data
+
+
+@pytest.mark.asyncio
+async def test_oidc_userinfo_accepts_resource_bound_token():
+    """UserInfo accepts a token whose aud is a resource URI (RFC 8707), not a
+    registered client_id."""
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    public_key = private_key.public_key()
+
+    payload = {
+        "sub": "user123",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 3600,
+        "iss": "http://localhost/oidc",
+        "aud": "http://localhost/api/mcp",  # resource, not a client_id
+        "azp": "test_client",
+        "scope": "openid profile",
+    }
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    token = jwt.encode(payload, private_key_pem, algorithm="RS256")
+
+    mock_user = Mock()
+    mock_user.id = "user123"
+    mock_user.name = "Test User"
+    mock_auth = Mock()
+    mock_auth.async_get_user = AsyncMock(return_value=mock_user)
+
+    hass = Mock()
+    hass.auth = mock_auth
+    hass.data = {
+        DOMAIN: {
+            "jwt_public_key": public_key,
+            "jwt_kid": "test-kid-1",
+            "clients": {},  # resource aud is intentionally not a registered client
+        }
+    }
+
+    mock_url = Mock()
+    mock_url.origin.return_value = "http://localhost"
+    request = Mock()
+    request.app = {"hass": hass}
+    request.headers = {"Authorization": f"Bearer {token}"}
+    request.url = mock_url
+
+    from custom_components.oidc_provider.http import OIDCUserInfoView
+
+    view = OIDCUserInfoView()
+    response = await view.get(request)
+
+    assert response.status == 200
+    data = json.loads(response.body.decode("utf-8"))
+    assert data["sub"] == "user123"
+    assert data["name"] == "Test User"
 
 
 @pytest.mark.asyncio

--- a/tests/test_token_validator.py
+++ b/tests/test_token_validator.py
@@ -457,3 +457,90 @@ def test_malformed_token_failure_logs_unparseable(mock_hass_with_keys, caplog):
 
     assert result is None
     assert any("header=<unparseable>" in record.getMessage() for record in caplog.records)
+
+
+def _encode(private_key, payload):
+    """Sign a JWT payload with the given RSA private key (RS256)."""
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return jwt.encode(payload, private_pem, algorithm="RS256")
+
+
+def _resource_token_payload(aud):
+    """Build an access-token payload bound to the given audience."""
+    return {
+        "sub": "user123",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 3600,
+        "iss": "https://ha.example.com/oidc",
+        "aud": aud,
+    }
+
+
+def test_validate_access_token_accepts_matching_resource_audience(mock_hass_with_keys):
+    """A token bound to the expected resource (RFC 8707) is accepted."""
+    hass, private_key = mock_hass_with_keys
+    hass.data[DOMAIN]["clients"] = {}  # resource is not a registered client
+
+    resource = "https://ha.example.com/api/mcp"
+    token = _encode(private_key, _resource_token_payload(resource))
+
+    result = validate_access_token(
+        hass, token, "https://ha.example.com", expected_audience=resource
+    )
+    assert result is not None
+    assert result["sub"] == "user123"
+
+
+def test_validate_access_token_rejects_resource_audience_mismatch(mock_hass_with_keys):
+    """A token for a different resource is rejected (confused deputy)."""
+    hass, private_key = mock_hass_with_keys
+    hass.data[DOMAIN]["clients"] = {}
+
+    token = _encode(private_key, _resource_token_payload("https://other.example.com/api/mcp"))
+
+    result = validate_access_token(
+        hass,
+        token,
+        "https://ha.example.com",
+        expected_audience="https://ha.example.com/api/mcp",
+    )
+    assert result is None
+
+
+def test_validate_access_token_accepts_audience_list(mock_hass_with_keys):
+    """An aud array containing the expected resource is accepted."""
+    hass, private_key = mock_hass_with_keys
+    hass.data[DOMAIN]["clients"] = {}
+
+    resource = "https://ha.example.com/api/mcp"
+    token = _encode(
+        private_key,
+        _resource_token_payload([resource, "https://ha.example.com/other"]),
+    )
+
+    result = validate_access_token(
+        hass, token, "https://ha.example.com", expected_audience=resource
+    )
+    assert result is not None
+
+
+def test_validate_access_token_legacy_client_audience_accepted(mock_hass_with_keys):
+    """A token with aud=client_id is still accepted even when a resource is
+    expected, so tokens issued before resource binding keep working."""
+    hass, private_key = mock_hass_with_keys
+    hass.data[DOMAIN]["clients"] = {"test_client": {}}
+
+    token = _encode(private_key, _resource_token_payload("test_client"))
+
+    result = validate_access_token(
+        hass,
+        token,
+        "https://ha.example.com",
+        expected_audience="https://ha.example.com/api/mcp",
+    )
+    assert result is not None
+    assert result["sub"] == "user123"


### PR DESCRIPTION
Connecting Claude (and other strict OAuth clients) failed right after a successful login with `oauth_error=McpAuthorizationError` / "the integration rejected the credentials". Two issues are fixed here.

**Audience not bound to the resource (RFC 8707).** Per the MCP authorization spec, clients send a `resource` indicator in the authorize and token requests and require the issued access token to be audience-bound to that resource. The provider dropped the `resource` parameter and always set `aud` to the `client_id`, so the token was rejected. `/oidc/authorize` now records `resource`, carries it through `/oidc/continue` into the authorization code, and the token endpoint binds the access token `aud` to it (the client is recorded in `azp`). The resource is persisted on the refresh token so refreshed access tokens keep the binding. `validate_access_token` gains an `expected_audience` argument; tokens whose `aud` is a registered `client_id` are still accepted for backward compatibility, and `/oidc/userinfo` accepts resource-bound tokens.

**Issuer advertised the wrong host behind a tunnel.** `get_issuer_from_request` only honored `X-Forwarded-Host` when `X-Forwarded-Proto` was also present, otherwise falling back to HA's configured external URL. Tunnels like Cloudflare forward the original `Host` header and `X-Forwarded-Proto` but omit `X-Forwarded-Host`, so discovery, the issuer, and every endpoint were advertised under HA's external (e.g. Nabu Casa) URL instead of the host the client actually used. It now derives the host from `X-Forwarded-Host` or the `Host` header, with the protocol from `X-Forwarded-Proto` or the request scheme.

Verified against a live instance: before, the issued access token's `aud` came back as the `client_id` despite a requested `resource` of `https://<host>/api/mcp`; after the audience change it is the resource.

Pairs with hass-mcp-server, which now validates the token audience against its own resource URI.

Addresses the `McpAuthorizationError` reports in #15. Version bumped to 1.5.0.
