### PR TITLE
fix: remove the login panel on unload so reloads succeed

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Anton Ganhammar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/custom_components/oidc_provider/__init__.py
+++ b/custom_components/oidc_provider/__init__.py
@@ -285,8 +285,8 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     # Home Assistant rejects a duplicate panel registration, so the panel has to
-    # go for the next setup to succeed. warn_if_unknown stays off because unload
-    # also runs on setups that failed before reaching the registration.
+    # go for the next setup to succeed. It is absent when unload runs against a
+    # setup that never registered one.
     async_remove_panel(hass, PANEL_URL_PATH, warn_if_unknown=False)
     hass.data[DOMAIN].clear()
     return True

--- a/custom_components/oidc_provider/__init__.py
+++ b/custom_components/oidc_provider/__init__.py
@@ -3,7 +3,10 @@
 import logging
 import time
 
-from homeassistant.components.frontend import async_register_built_in_panel
+from homeassistant.components.frontend import (
+    async_register_built_in_panel,
+    async_remove_panel,
+)
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -11,7 +14,13 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.storage import Store
 
 from .client_manager import create_client
-from .const import CONF_REQUIRE_PKCE, DEFAULT_REQUIRE_PKCE, DOMAIN, STORAGE_KEY_TOKENS
+from .const import (
+    CONF_REQUIRE_PKCE,
+    DEFAULT_REQUIRE_PKCE,
+    DOMAIN,
+    PANEL_URL_PATH,
+    STORAGE_KEY_TOKENS,
+)
 from .http import setup_http_endpoints
 
 _LOGGER = logging.getLogger(__name__)
@@ -83,7 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         component_name="custom",
         sidebar_title=None,  # Hidden from sidebar
         sidebar_icon=None,
-        frontend_url_path="oidc_login",
+        frontend_url_path=PANEL_URL_PATH,
         config={
             "_panel_custom": {
                 "name": "oidc-auth-panel",
@@ -275,5 +284,9 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    # Home Assistant rejects a duplicate panel registration, so the panel has to
+    # go for the next setup to succeed. warn_if_unknown stays off because unload
+    # also runs on setups that failed before reaching the registration.
+    async_remove_panel(hass, PANEL_URL_PATH, warn_if_unknown=False)
     hass.data[DOMAIN].clear()
     return True

--- a/custom_components/oidc_provider/const.py
+++ b/custom_components/oidc_provider/const.py
@@ -63,3 +63,6 @@ RATE_LIMIT_PENALTY = 60  # Lockout period in seconds after max attempts
 # PKCE enforcement
 DEFAULT_REQUIRE_PKCE = True  # Default to required for security (OAuth 2.1 compliance)
 CONF_REQUIRE_PKCE = "require_pkce"
+
+# Frontend panel serving the login flow (hidden from the sidebar)
+PANEL_URL_PATH = "oidc_login"

--- a/custom_components/oidc_provider/http.py
+++ b/custom_components/oidc_provider/http.py
@@ -33,6 +33,7 @@ from .const import (
     HA_GROUP_TO_OIDC_GROUP,
     ID_TOKEN_EXPIRY,
     MAX_TOKEN_ATTEMPTS,
+    PANEL_URL_PATH,
     RATE_LIMIT_PENALTY,
     RATE_LIMIT_WINDOW,
     REFRESH_TOKEN_EXPIRY,
@@ -468,7 +469,7 @@ class OIDCAuthorizationView(HomeAssistantView):
             <p>Redirecting to login...</p>
             <script>
                 sessionStorage.setItem('oidc_request_id', '{escaped_request_id}');
-                window.location.href = '/oidc_login';
+                window.location.href = '/{PANEL_URL_PATH}';
             </script>
         </body>
         </html>

--- a/custom_components/oidc_provider/manifest.json
+++ b/custom_components/oidc_provider/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-oidc-server/issues",
   "requirements": ["PyJWT>=2.8.0", "cryptography>=43.0.0"],
-  "version": "1.5.0"
+  "version": "1.5.1"
 }

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -4,6 +4,7 @@ import time
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from homeassistant.components.frontend import DATA_PANELS
 
 from custom_components.oidc_provider import (
     DOMAIN,
@@ -11,6 +12,7 @@ from custom_components.oidc_provider import (
     async_setup_entry,
     async_unload_entry,
 )
+from custom_components.oidc_provider.const import PANEL_URL_PATH
 
 
 @pytest.fixture
@@ -264,6 +266,47 @@ class TestAsyncUnloadEntry:
 
         assert result is True
         assert len(mock_hass.data[DOMAIN]) == 0
+
+    async def test_async_unload_entry_without_panel(self, mock_hass, mock_config_entry):
+        """Test async_unload_entry succeeds when the panel was never registered."""
+        mock_hass.data[DOMAIN] = {}
+
+        result = await async_unload_entry(mock_hass, mock_config_entry)
+
+        assert result is True
+
+
+class TestReload:
+    """Test the unload/setup cycle that a config entry reload performs."""
+
+    @patch("custom_components.oidc_provider.Store")
+    @patch("custom_components.oidc_provider.setup_http_endpoints")
+    async def test_reload_re_registers_panel(
+        self,
+        mock_http,
+        mock_store_class,
+        mock_hass,
+        mock_config_entry,
+    ):
+        """Test reloading does not trip Home Assistant's duplicate-panel guard.
+
+        The frontend panel helpers are deliberately left unmocked so the real
+        "Overwriting panel" guard runs against the real panel registry.
+        """
+        mock_store_class.side_effect = lambda *args, **kwargs: Mock(
+            async_load=AsyncMock(return_value=None), async_save=AsyncMock()
+        )
+
+        assert await async_setup_entry(mock_hass, mock_config_entry) is True
+        assert PANEL_URL_PATH in mock_hass.data[DATA_PANELS]
+
+        assert await async_unload_entry(mock_hass, mock_config_entry) is True
+        assert PANEL_URL_PATH not in mock_hass.data[DATA_PANELS]
+
+        # Raises ValueError("Overwriting panel oidc_login") if unload leaves the
+        # panel registered.
+        assert await async_setup_entry(mock_hass, mock_config_entry) is True
+        assert PANEL_URL_PATH in mock_hass.data[DATA_PANELS]
 
 
 class TestRegisterClientService:


### PR DESCRIPTION
Reloading the config entry, or any options change that triggers re-setup, left the integration permanently broken until a full Home Assistant restart.

`async_setup_entry` registers the `oidc_login` frontend panel, but `async_unload_entry` only cleared `hass.data`, so the panel stayed in Home Assistant's registry across the unload. The next setup hit the duplicate guard in `homeassistant/components/frontend/__init__.py` and raised `ValueError: Overwriting panel oidc_login`, and the entry stayed in a failed state.

`async_unload_entry` now removes the panel, with `warn_if_unknown=False` so an unload that finds no panel stays quiet. The url path moves into a `PANEL_URL_PATH` constant shared by the registration, the removal, and the redirect that `/oidc/authorize` serves. That last one is the reason the constant is worth having: it previously hardcoded `/oidc_login`, so a change to the path would have kept registration and removal in step while sending users to a 404.

Every existing setup test patches `async_register_built_in_panel`, which is why the suite stayed green while the bug shipped. The new `TestReload` case deliberately leaves the frontend helpers unmocked and drives setup, unload and setup against the real panel registry, so it reproduces the `ValueError` without this fix.

Also adds an MIT `LICENSE`, matching hass-mcp-server. HACS validation fails the repository without one, unrelated to this bug but currently red on every PR and on main.

Closes #29. This is also the underlying cause of #5, which was closed without a fix.

### Not addressed here

Three other things leak across a reload, all pre-existing, so they are worth their own change rather than widening this one:

- `setup_http_endpoints` re-registers all nine views on every setup. Home Assistant calls `router.add_route` without a `name`, so aiohttp accepts the duplicates and resolves to whichever was registered first. The router grows by nine routes per reload and the original instances keep serving. The endpoints also stay live after unload, and since unload clears `hass.data[DOMAIN]` they raise `KeyError` rather than returning a clean 503.
- The `/oidc_provider` static path is re-registered the same way.
- Services are never unregistered on unload.

Worth noting that this fix is what makes those reachable. Reload currently hard-fails, so nobody accumulates routes; once reload succeeds they compound quietly, which argues for following up before 1.5.1 rather than after.

The signing key is unaffected: `_load_or_generate_keys` persists it through `Store`, so a reload reuses the same `kid` and issued tokens stay valid.
