### PR TITLE
fix: prefer external URL over IP Host header in issuer resolution

### DIFF
--- a/custom_components/oidc_provider/token_validator.py
+++ b/custom_components/oidc_provider/token_validator.py
@@ -1,5 +1,6 @@
 """Token validation helper for OIDC provider."""
 
+import ipaddress
 import logging
 from typing import Any
 
@@ -35,6 +36,16 @@ def _describe_token(token: str) -> str:
     return " ".join(parts)
 
 
+def _is_ip_host(host: str) -> bool:
+    """Return True when host (optionally host:port) is a bare IP address."""
+    bare = host.rsplit(":", 1)[0] if ":" in host and not host.endswith("]") else host
+    try:
+        ipaddress.ip_address(bare.strip("[]"))
+    except ValueError:
+        return False
+    return True
+
+
 def get_issuer_from_request(request: web.Request) -> str:
     """
     Get the expected issuer URL from a request.
@@ -57,14 +68,20 @@ def get_issuer_from_request(request: web.Request) -> str:
     host = request.headers.get("X-Forwarded-Host") or request.headers.get("Host")
     proto = request.headers.get("X-Forwarded-Proto") or request.url.scheme
 
-    if host:
+    if host and not _is_ip_host(host):
         return f"{proto}://{host}"
 
-    # No usable host header: fall back to HA's configured external URL, then the
-    # raw request origin.
+    # The host is missing or is an IP address. Some proxies (e.g. Keenetic)
+    # rewrite Host to the internal IP without setting X-Forwarded-Host, which
+    # would leak the internal address into the issuer and endpoint metadata.
+    # Prefer HA's configured external URL in that case; keep the IP host as a
+    # fallback so LAN-only installs without an external URL keep working.
     external_url = _get_ha_external_url(request)
     if external_url:
         return external_url.rstrip("/")
+
+    if host:
+        return f"{proto}://{host}"
 
     return str(request.url.origin())
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -132,6 +132,103 @@ def test_get_base_url_strips_trailing_slash_from_external_url():
     assert result == "https://my-ha.example.com"
 
 
+def test_get_base_url_ip_host_prefers_external_url():
+    """A proxy that rewrites Host to the internal IP (no X-Forwarded-Host)
+    must not leak the internal address; the configured external URL wins."""
+    request = Mock()
+    request.headers = {
+        "Host": "192.168.2.20:8123",
+    }
+    request.url.scheme = "http"
+    request.url.origin.return_value = "http://192.168.2.20:8123"
+
+    with patch(
+        "custom_components.oidc_provider.token_validator._get_ha_external_url",
+        return_value="https://ha.example.com",
+    ):
+        result = get_issuer_from_request(request)
+
+    assert result == "https://ha.example.com"
+    request.url.origin.assert_not_called()
+
+
+def test_get_base_url_forwarded_ip_host_prefers_external_url():
+    """X-Forwarded-Host set to an IP is treated the same as a rewritten Host."""
+    request = Mock()
+    request.headers = {
+        "X-Forwarded-Proto": "https",
+        "X-Forwarded-Host": "192.168.2.20",
+    }
+    request.url.scheme = "http"
+    request.url.origin.return_value = "http://192.168.2.20:8123"
+
+    with patch(
+        "custom_components.oidc_provider.token_validator._get_ha_external_url",
+        return_value="https://ha.example.com",
+    ):
+        result = get_issuer_from_request(request)
+
+    assert result == "https://ha.example.com"
+
+
+def test_get_base_url_ip_host_kept_without_external_url():
+    """LAN-only installs with no external URL keep the IP host as issuer."""
+    request = Mock()
+    request.headers = {
+        "Host": "192.168.2.20:8123",
+    }
+    request.url.scheme = "http"
+    request.url.origin.return_value = "http://192.168.2.20:8123"
+
+    with patch(
+        "custom_components.oidc_provider.token_validator._get_ha_external_url",
+        return_value=None,
+    ):
+        result = get_issuer_from_request(request)
+
+    assert result == "http://192.168.2.20:8123"
+    request.url.origin.assert_not_called()
+
+
+def test_get_base_url_ipv6_host_prefers_external_url():
+    """Bracketed IPv6 hosts are recognized as IP addresses."""
+    request = Mock()
+    request.headers = {
+        "Host": "[fd00::20]:8123",
+    }
+    request.url.scheme = "http"
+    request.url.origin.return_value = "http://[fd00::20]:8123"
+
+    with patch(
+        "custom_components.oidc_provider.token_validator._get_ha_external_url",
+        return_value="https://ha.example.com",
+    ):
+        result = get_issuer_from_request(request)
+
+    assert result == "https://ha.example.com"
+
+
+def test_get_base_url_domain_host_ignores_external_url():
+    """A real domain in Host keeps winning over the external URL (no behavior
+    change for tunnels that forward the original Host)."""
+    request = Mock()
+    request.headers = {
+        "X-Forwarded-Proto": "https",
+        "Host": "hem.example.com",
+    }
+    request.url.scheme = "http"
+    request.url.origin.return_value = "http://localhost:8123"
+
+    with patch(
+        "custom_components.oidc_provider.token_validator._get_ha_external_url",
+        return_value="https://other.example.com",
+    ) as mock_external:
+        result = get_issuer_from_request(request)
+
+    assert result == "https://hem.example.com"
+    mock_external.assert_not_called()
+
+
 def test_get_base_url_falls_back_to_origin_when_no_external_url():
     """Test fallback to request origin when HA external URL is not configured."""
     request = Mock()


### PR DESCRIPTION
all 225 tests pass including five new ones for this fix

- _is_ip_host() helper (handles host:port and bracketed IPv6) + import ipaddress at module top.

- Resolution order becomes: domain host → external URL → IP host → request origin. So a real domain in Host/X-Forwarded-Host behaves exactly as before (no change for the Cloudflare Tunnel case from 1.5.0), and LAN-only installs with no external URL still get their IP issuer — the IP is demoted, not dropped.

- Five new tests in tests/test_http.py matching their mock style: IP Host + external URL → external URL wins; IP in X-Forwarded-Host treated the same; IP kept when no external URL (the LAN case); bracketed IPv6; and a guard test proving a domain host still ignores the external URL.