### PR TITLE
chore: describe issuer resolution order in docstring and bump to 1.5.2

### DIFF
--- a/custom_components/oidc_provider/manifest.json
+++ b/custom_components/oidc_provider/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-oidc-server/issues",
   "requirements": ["PyJWT>=2.8.0", "cryptography>=43.0.0"],
-  "version": "1.5.1"
+  "version": "1.5.2"
 }

--- a/custom_components/oidc_provider/token_validator.py
+++ b/custom_components/oidc_provider/token_validator.py
@@ -50,9 +50,10 @@ def get_issuer_from_request(request: web.Request) -> str:
     """
     Get the expected issuer URL from a request.
 
-    Respects X-Forwarded headers if present (for reverse proxy setups).
-    Falls back to Home Assistant's configured external URL when headers
-    are absent, before using the raw request origin.
+    Resolution order: a domain host from X-Forwarded-Host or Host wins
+    (for reverse proxy setups). When the host is missing or a bare IP
+    address, Home Assistant's configured external URL is preferred,
+    followed by the IP host and finally the raw request origin.
 
     Args:
         request: The aiohttp web request


### PR DESCRIPTION
Follow-up to #34 covering the review findings and the release bump:

- Update the `get_issuer_from_request` docstring to describe the actual resolution order (domain host, then configured external URL, then IP host, then request origin).
- Bump the version to 1.5.2 so the issuer fix from #34 gets released.

Upgrade note: on installs where clients reach Home Assistant via a LAN IP while an external URL is configured, the issuer changes from the IP origin to the external URL. Access tokens issued before this release with an IP issuer will fail validation, so affected clients need to re-authenticate. Those clients are also handed external-URL endpoints in the discovery metadata, so the external URL must be reachable from inside the network.
